### PR TITLE
Point package metadata to public repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,10 @@ dev = ["build>=1.2", "twine>=5.1"]
 skilgen = "skilgen.cli.main:console_main"
 
 [project.urls]
-Homepage = "https://github.com/RaviChanduUmmadisetti/skilgen"
-Repository = "https://github.com/RaviChanduUmmadisetti/skilgen"
-Issues = "https://github.com/RaviChanduUmmadisetti/skilgen/issues"
+Homepage = "https://github.com/skilgen/skilgen"
+Repository = "https://github.com/skilgen/skilgen"
+Issues = "https://github.com/skilgen/skilgen/issues"
+
 
 [tool.setuptools]
 license-files = ["LICENSE"]


### PR DESCRIPTION
## Summary

This PR fixes the broken `skillayer-web` deploy path by moving the deploy flow to the monorepo root, matching the working dashboard pattern.

## What changed

### Web deploy fix
- Added `vercel.web.json` at the repo root
- Added `scripts/deploy_web.py` to swap the root Vercel project link to `apps/web/.vercel/project.json`
- Added `deploy:web` to the root `package.json`
- Updated `apps/web/vercel.json` to the shared root build/output settings

## Deployment verification

### Web
- `npx turbo build --filter=skillayer-web` passed
- `python3 scripts/deploy_web.py --prod` produced READY deployment `dpl_HHGM81zGyHnFm8SR3Gi4A6RXrwqb`
- `vercel promote dpl_HHGM81zGyHnFm8SR3Gi4A6RXrwqb --scope ravichandu999-7992s-projects` re-asserted production promotion
- `www.skillayer.com` now resolves to deployment `dpl_HHGM81zGyHnFm8SR3Gi4A6RXrwqb`
- Browser verification passed for:
  - homepage load
  - pricing navigation anchor
  - primary CTA to sign-in flow

### API
- `python3 scripts/deploy_api.py --prod` produced READY deployment `dpl_G4TkVNXkADL2KdXe4MQmth5ABGbH`
- Public API checks passed for `/health`, `/metrics`, and `/registry`

## Neon migration status

The remaining blocker is proving the production Neon migration end-to-end from this machine.

What I verified:
- `apps/api/.env.local` contains a Neon URL, but direct DB auth fails with `password authentication failed for user 'neondb_owner'`
- Vercel production envs for `skillayer-api` do contain `DATABASE_URL`, but `vercel env pull` returns empty secret values in this session
- Neon MCP access is currently expired in this session
- The API app startup calls `alembic upgrade head`, but migration errors are swallowed, so a healthy `/health` does not prove the migration succeeded

So:
- web deployment is fixed and public
- public API surface is healthy
- migration-dependent endpoints are **not yet conclusively verified** from this machine

### Manual follow-up if needed
Run this from `apps/api/` with a working Neon connection string:

```bash
DATABASE_URL=<your-neon-url> python -m alembic upgrade head
```

Then verify:

```sql
SELECT column_name
FROM information_schema.columns
WHERE table_name = 'skills'
  AND column_name IN ('source_type', 'skill_category')
ORDER BY column_name;
```
