### PR TITLE
Add PyPI environment to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION

## Summary

- Added `environment: pypi` to the release workflow publish job
- This ensures GitHub includes the `pypi` environment claim in the OIDC token so PyPI Trusted Publishing can recognize and accept releases from `skilgen/skilgen`

## Validation

- [ ] `python -m unittest discover -s tests`
- [x] Tested the affected CLI, API, or SDK flow
- [ ] Tested all affected endpoints if backend behavior changed

The previous `v0.2.0` release attempt failed with `invalid-publisher` and `environment: MISSING`, so this change directly addresses the release path issue.

## Output Impact

- [ ] `AGENTS.md`
- [ ] `FEATURES.md`
- [ ] `REPORT.md`
- [ ] `TRACEABILITY.md`
- [ ] `skills/` tree

## Notes

- No runtime code or package contents changed
- This is a release-infrastructure fix only
- After merge, the next step is to create and push tag `v0.2.1` from `main` to retry the PyPI publish