### PR TITLE
Add Skilgen Score, dynamic skill drilldowns, and git-aware refresh signals

### DIFF
--- a/.github/workflows/skilgen-sync.yml
+++ b/.github/workflows/skilgen-sync.yml
@@ -1,0 +1,61 @@
+name: Skilgen Sync
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+jobs:
+  skilgen-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Skilgen
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
+      - name: Initialize config if needed
+        run: |
+          if [ ! -f skilgen.yml ]; then
+            python -m skilgen.cli.main init --project-root .
+          fi
+      - name: Deliver latest skills
+        run: python -m skilgen.cli.main deliver --project-root .
+      - name: Validate generated outputs
+        run: python -m skilgen.cli.main validate --project-root . > skilgen-validate.json
+      - name: Compute Skilgen Score
+        run: python -m skilgen.cli.main score --project-root . --badge-file skilgen-score.svg > skilgen-score.json
+      - name: Upload score and validation artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: skilgen-quality
+          path: |
+            skilgen-score.json
+            skilgen-score.svg
+            skilgen-validate.json
+      - name: Append workflow summary
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          score = json.loads(Path("skilgen-score.json").read_text())
+          validate = json.loads(Path("skilgen-validate.json").read_text())
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write(f"## Skilgen Score: {int(round(score['score']))}/100\n\n")
+              handle.write(f"- Groundedness: {score['subscores']['groundedness']['score']}/25\n")
+              handle.write(f"- Coverage: {score['subscores']['coverage']['score']}/25\n")
+              handle.write(f"- Freshness: {score['subscores']['freshness']['score']}/25\n")
+              handle.write(f"- Structure: {score['subscores']['structure']['score']}/25\n")
+              handle.write(f"- Validation warnings: {len(validate['warnings'])}\n")
+              handle.write(f"- Validation errors: {len(validate['errors'])}\n")
+          PY

--- a/README.md
+++ b/README.md
@@ -1,304 +1,476 @@
 <p align="center">
-  <img src="docs/assets/skilgen.svg" alt="Skilgen" width="280" />
+  <img src="docs/assets/skilgen.svg" alt="Skilgen logo" width="560" />
 </p>
 
 <h1 align="center">Skilgen</h1>
 
 <p align="center">
-  <strong>The living skill system for AI coding agents.</strong><br/>
-  Turn a codebase, a PRD, or both into a self-updating skill tree that keeps agents in sync with your code as it evolves.
+  Install Skilgen once, run it in your repo, and let it keep your agent skills, docs, enterprise context, and approved MCP connectors up to date automatically.
 </p>
 
 <p align="center">
-  <a href="https://pypi.org/project/skilgen/"><img src="https://img.shields.io/pypi/v/skilgen?color=blue" alt="PyPI" /></a>
-  <a href="https://github.com/skilgen/skilgen/blob/main/LICENSE"><img src="https://img.shields.io/github/license/skilgen/skilgen" alt="License" /></a>
-  <a href="https://github.com/skilgen/skilgen/stargazers"><img src="https://img.shields.io/github/stars/skilgen/skilgen?style=social" alt="Stars" /></a>
-  <a href="https://agentskills.io/specification"><img src="https://img.shields.io/badge/Agent_Skills-compatible-green" alt="Agent Skills compatible" /></a>
+  <a href="https://pypi.org/project/skilgen/"><img src="https://img.shields.io/pypi/v/skilgen" alt="PyPI version" /></a>
+  <a href="https://pypi.org/project/skilgen/"><img src="https://img.shields.io/pypi/pyversions/skilgen" alt="Python versions" /></a>
+  <a href="https://github.com/skilgen/skilgen/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/skilgen/skilgen/ci.yml?branch=main" alt="CI status" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT license" /></a>
 </p>
 
----
-
-## The Problem
-
-Every AI coding agent — Claude Code, Codex, Copilot, Cursor — starts from scratch. It doesn't know your architecture, your domain boundaries, your implementation patterns, or your product requirements. You re-explain the same context in every conversation. You write skills by hand. They go stale the moment your code changes. There's no way to know if a skill still reflects reality.
-
-## What Skilgen Does
-
-Skilgen reads your codebase, your requirements, or both — and generates a complete, production-grade skill tree that agents can use immediately. Then it **watches your code and auto-regenerates stale skills when things change**.
-
-```
-skilgen deliver --project-root . --requirements docs/prd.docx
-```
-
-That one command produces:
-
-```
-.
-├── FEATURES.md            # Product behavior inventory
-├── REPORT.md              # Project-level understanding
-├── TRACEABILITY.md        # Source → output reasoning
-├── AGENTS.md              # Agent operating guide
-└── skills/
-    ├── MANIFEST.md        # Entry-point discovery
-    ├── requirements/
-    │   ├── SKILL.md       # PRD-grounded guidance
-    │   └── SUMMARY.md
-    ├── backend/
-    │   ├── SKILL.md       # Backend domain guidance
-    │   ├── api/SKILL.md
-    │   ├── auth/SKILL.md
-    │   ├── data/SKILL.md
-    │   └── testing/SKILL.md
-    ├── frontend/
-    │   ├── SKILL.md
-    │   └── components/SKILL.md
-    └── roadmap/
-        ├── SKILL.md
-        └── phase-*/SKILL.md
-```
-
-Every generated skill references **real files, real patterns, and real domain boundaries** from your codebase — not generic LLM advice.
-
----
-
-## How Skilgen Compares
-
-| Capability | Skilgen | Anthropic<br/>`skill-creator` | OpenAI Codex<br/>`$skill-creator` | Skill Seekers | skills.sh /<br/>SkillKit |
-|:---|:---:|:---:|:---:|:---:|:---:|
-| Codebase → full skill tree | ✅ | — | — | Single file | — |
-| PRD → skill tree | ✅ | — | — | — | — |
-| Codebase + PRD combined | ✅ | — | — | — | — |
-| Auto-update on code changes | ✅ | — | — | — | — |
-| Freshness & drift detection | ✅ | — | — | — | — |
-| Project memory across runs | ✅ | — | — | — | — |
-| Domain graph with cross-refs | ✅ | — | — | — | — |
-| Enterprise MCP connector catalog | ✅ | — | — | — | — |
-| External skill trust scoring | ✅ | — | — | — | — |
-| Multi-model provider support | ✅ | Claude only | OpenAI only | Claude / Gemini | N/A |
-| Python SDK + HTTP API | ✅ | — | — | — | — |
-| Eval / benchmark loop | — | ✅ | — | — | — |
-| Skill install & distribution | Via catalog | Via plugin | Via `$skill-installer` | — | ✅ |
-
-Anthropic and OpenAI ship **interactive wizards** that help you write one skill at a time. Skill Seekers generates a single skill file from docs or repos. skills.sh and SkillKit are distribution platforms for installing existing skills.
-
-Skilgen generates an **entire living skill tree** — grounded in your actual codebase and requirements — that auto-updates, tracks drift, and remembers project context across runs.
-
----
-
-## Why Skilgen
-
-### Skills That Stay Alive
-
-Other tools generate a skill file and forget about it. Skilgen is a **living system**.
-
-Set `update_trigger: auto` in your config and Skilgen runs a background worker that watches your project. When Claude Code, Codex, or any tool changes a file, Skilgen detects it, identifies which skills are affected, and regenerates only what's stale.
-
-```bash
-skilgen autoupdate enable --project-root .
-
-# Skills auto-regenerate when your code changes.
-# No manual intervention. No stale context. Ever.
-```
-
-### It Knows When Skills Are Out of Date
-
-Skilgen tracks the freshness of every generated skill against every source file. At any point you can ask:
-
-```bash
-skilgen status --project-root .
-```
-
-And it tells you which source files changed, which domains are impacted, and which skills need a refresh — with a clear reason why.
-
-No other tool does this.
-
-### Codebase + PRD = Highest Fidelity
-
-Most skill generators work from either code or docs. Skilgen can take both and cross-reference them:
-
-- **Codebase only** -> skills grounded in what exists today
-- **PRD only** -> skills grounded in what you intend to build
-- **Both together** -> skills that bridge implementation reality with product intent
-
-```bash
-# From codebase only
-skilgen deliver --project-root .
-
-# From a PRD only
-skilgen intent --requirements docs/prd.docx
-
-# Both together for the best output
-skilgen deliver --project-root . --requirements docs/prd.docx
-```
-
-### Deep Analysis, Not a Prompt Wrapper
-
-Skilgen doesn't send your codebase to an LLM with a single prompt and hope for the best. It runs a **multi-agent analysis pipeline** that decomposes your project into frameworks, signals, domains, relationships, features, and a roadmap — then synthesizes all of that into a coherent skill tree with cross-references.
-
-The result: skills that understand your backend routes talk to your auth layer, that your frontend components depend on specific API contracts, and that your test suite covers certain domains but not others.
-
-### Project Memory
-
-Skilgen remembers across runs. It persists project context — domains, priorities, architectural decisions, and freshness state — so each subsequent run is smarter than the last. It knows what changed, what to skip, and what to focus on.
-
-### Enterprise MCP Connector Discovery
-
-Skilgen ships with a curated catalog of enterprise MCP connectors — Jira, Confluence, Slack, GitHub Enterprise, GitLab, Azure, Terraform, Datadog, Snowflake, Stripe, Figma, and more — each with verified source URLs, OAuth metadata, and enterprise-readiness flags.
-
-```bash
-# Auto-detect which connectors your codebase needs
-skilgen connectors recommend --project-root .
-
-# Activate one
-skilgen connectors activate jira --project-root .
-```
-
-Skilgen scans your codebase, detects which tools you use, and recommends only what's relevant — respecting your allowlist, denylist, and security policy.
-
-### External Skill Sources With Trust Scoring
-
-Skilgen catalogs skill collections from across the ecosystem — Anthropic, LangChain, Hugging Face, AgentSkills.io, and community sources — and scores each by trust level so you know what you're installing.
-
-```bash
-# Browse available sources
-skilgen skills list
-
-# Install from the catalog
-skilgen skills install --slug anthropic-skills
-
-# Rank by trust
-skilgen skills rank
-
-# Lock versions for reproducibility
-skilgen skills lock export
-```
-
-Enterprise teams can enforce policy: restrict trust levels, allowlist specific sources, and lock versions across the organization.
-
-### Enterprise Skill Packs
-
-Ingest organization-wide skills from shared repos or internal paths — coding standards, architectural guidelines, security conventions — and have agents load them alongside project-local skills.
-
-```bash
-# Ingest from a git repo
-skilgen enterprise ingest --name corporate-standards \
-  --git-url https://github.com/your-org/engineering-skills.git
-
-# Generate from internal source files
-skilgen enterprise generate --name auth-patterns \
-  --source-paths src/auth/ docs/auth-spec.md
-```
-
-### Works With Every Major Model Provider
-
-```yaml
-model_provider: openai        # or anthropic, gemini, huggingface, groq, openrouter
-model: gpt-4.1-mini           # any model from your provider
-api_key_env: OPENAI_API_KEY   # auto-mapped per provider
-```
-
-No API key? Skilgen falls back to a **local deterministic runtime** — faster, no cost, still functional.
-
----
+<p align="center">
+  Skilgen is the repo-local skill system for Codex, Claude Code, Cursor, and other coding agents. It generates and refreshes the files agents actually need inside the repository they are working on.
+</p>
 
 ## Quick Start
 
-```bash
-pip install skilgen
-```
+Install Skilgen from PyPI:
 
 ```bash
-# Initialize config
+python -m pip install skilgen
+```
+
+Export a provider key if you want the full model-backed runtime:
+
+```bash
+export OPENAI_API_KEY="your_key_here"
+# or
+export ANTHROPIC_API_KEY="your_key_here"
+# or
+export HUGGINGFACEHUB_API_TOKEN="your_token_here"
+```
+
+Initialize the repo and let Skilgen start its repo-local skill system:
+
+```bash
 skilgen init --project-root .
-
-# See what Skilgen detects in your codebase
-skilgen fingerprint --project-root .
-
-# Generate the full skill tree
 skilgen deliver --project-root .
-
-# Or combine with a PRD for the highest-fidelity output
-skilgen deliver --project-root . --requirements docs/prd.docx
-
-# Enable auto-update (skills regenerate when code changes)
-skilgen autoupdate enable --project-root .
+skilgen status --project-root .
 ```
 
-Requires Python 3.11+.
+That’s the whole idea:
+1. install Skilgen
+2. run it once in a repo
+3. let Skilgen keep the repo-local agent context fresh as code changes
 
----
+## What Skilgen Does
 
-## Commands
+Skilgen turns your repository into an agent-ready operating system that stays current as the code changes.
 
-| Command | What It Does |
-|---|---|
-| `skilgen init` | Write a default `skilgen.yml` config |
-| `skilgen fingerprint` | Detect frameworks, stack, and project shape |
-| `skilgen map` | Build an import relationship map |
-| `skilgen analyze` | Full framework, signal, and relationship analysis |
-| `skilgen decide` | Recommend which skills to refresh and prioritize |
-| `skilgen intent` | Parse a requirements file into structured intent |
-| `skilgen features` | Build a feature inventory from code + requirements |
-| `skilgen plan` | Generate a phased roadmap |
-| `skilgen deliver` | Run the full generation flow |
-| `skilgen update` | Refresh outputs for selected domains |
-| `skilgen preview` | Dry-run: see what would be generated without writing |
-| `skilgen watch` | Foreground file watcher with continuous regeneration |
-| `skilgen autoupdate` | Manage the background auto-update daemon |
-| `skilgen status` | Show freshness state and generated output status |
-| `skilgen report` | Summary report for the project |
-| `skilgen validate` | Validate generated outputs and skill references |
-| `skilgen doctor` | Diagnose runtime, model config, and API key setup |
-| `skilgen skills` | Discover, install, and manage external skill sources |
-| `skilgen enterprise` | Ingest and generate enterprise-wide skill packs |
-| `skilgen connectors` | Discover and manage approved MCP connectors |
-| `skilgen scan` | Generate docs and skills (alias for deliver) |
-| `skilgen serve` | Run the HTTP API server |
+When you run Skilgen in a repo, it can:
+- generate and refresh `AGENTS.md`, `FEATURES.md`, `REPORT.md`, and `TRACEABILITY.md`
+- generate and refresh a project `skills/` tree
+- detect changed code and refresh skills automatically
+- score the quality of the skill tree with a verifiable `Skilgen Score`
+- ingest enterprise-wide skill packs
+- install and rank external skill ecosystems
+- recommend and activate approved official MCP connectors
+- decide what an agent should load first before it starts working
 
----
+## Why Teams Use It
 
-## Python SDK
+Most AI coding sessions fail for the same reasons:
+- the agent starts without the real repo context
+- guidance gets stale after code changes
+- enterprise knowledge is scattered across docs, runbooks, and tribal memory
+- tool access is not governed or consistent
 
-```python
-import skilgen
+Skilgen fixes that by giving the repo a living skill system instead of a one-time prompt.
 
-# Generate the full skill tree
-skilgen.deliver_project("docs/prd.docx", ".")
+## Skilgen Score
 
-# Fingerprint the codebase
-result = skilgen.fingerprint_codebase(".")
+Skilgen Score is the quality bar for a skill tree.
 
-# Get freshness status
-status = skilgen.project_status(".")
+It is a `0-100` score with four `0-25` subscores:
 
-# Start/stop auto-update
-skilgen.start_auto_update(".", requirements="docs/prd.docx")
-skilgen.stop_auto_update(".")
+| Subscore | What It Measures | What A High Score Means |
+| --- | --- | --- |
+| Groundedness | How much the skill system points to real files, paths, and repo evidence | skills are specific to the codebase, not generic advice |
+| Coverage | How much of the real codebase is mapped into skill domains | major repo areas are represented in the skill tree |
+| Freshness | Whether skills are current relative to current code and saved freshness state | the skill system is up to date |
+| Structure | Whether the repo has the right artifacts, cross-links, and traceability | the skill tree is complete, navigable, and valid |
 
-# Manage external skills
-skilgen.install_skill_source(".", slug="anthropic-skills")
-skilgen.rank_skill_sources(".")
+Run it like this:
 
-# Enterprise features
-skilgen.recommend_project_mcp_connectors(".")
-skilgen.activate_project_mcp_connector("jira", ".")
-
-# Background jobs
-job = skilgen.start_deliver_job("docs/prd.docx", ".")
-skilgen.get_job_status(job["job_id"])
+```bash
+skilgen score --project-root .
 ```
 
----
+Skilgen Score is intentionally opinionated:
+- stale skills cap the score
+- weak grounding caps the score
+- weak coverage caps the score
+- missing `AGENTS.md`, `TRACEABILITY.md`, `MANIFEST.md`, or `GRAPH.md` caps the score
 
-## HTTP API
+That means a high score signals real quality, not just lots of generated files.
 
-Run `skilgen serve` to start the API server. Every CLI command is available as an HTTP endpoint for CI pipelines, platform integrations, and internal tooling.
+## What Agents Get Immediately
 
----
+Skilgen prepares the files that coding agents actually need inside the repository:
+- `AGENTS.md`
+- `skills/`
+- `FEATURES.md`
+- `REPORT.md`
+- `TRACEABILITY.md`
+- `.skilgen/` state and memory
 
-## Configuration
+That gives agents:
+- repo-specific instructions instead of repeated prompting
+- freshness-aware context instead of stale assumptions
+- ranked external and enterprise skills when they matter
+- approved MCP capability context when enterprise tools are available
 
-`skilgen init` writes a `skilgen.yml` with sensible defaults:
+## How It Works
+
+Skilgen is a Python package you install in your environment.
+
+Codex or Claude Code do **not** need Skilgen inside `~/.codex` to use it.
+
+Instead, Skilgen prepares the **repository itself** so the agent can read:
+- `AGENTS.md`
+- `skills/`
+- `FEATURES.md`
+- `REPORT.md`
+- `TRACEABILITY.md`
+- `.skilgen/` state and memory
+
+Think of the layers like this:
+
+- `~/.codex`
+  - your global Codex home, personal defaults, and Codex-specific setup
+- `your-repo/AGENTS.md` and `your-repo/skills/`
+  - the repo-local operating context that Skilgen creates and keeps fresh
+
+That means the workflow is:
+1. install Skilgen
+2. run it inside a repo
+3. let Skilgen generate and update the repo-local skill system
+4. let Codex, Claude Code, or Cursor use that repo-local context while coding
+
+## Quick Flow
+
+```mermaid
+flowchart TD
+    A["Install Skilgen"] --> B["Run skilgen init in a repo"]
+    B --> C["Skilgen creates repo-local config and starts auto-update"]
+    C --> D["Skilgen analyzes code, requirements, enterprise skills, and MCP signals"]
+    D --> E["Skilgen writes AGENTS.md, skills/, reports, and .skilgen state"]
+    E --> F["Codex / Claude Code / Cursor read the repo-local files"]
+    F --> G["Developer or agent changes code"]
+    G --> H["Skilgen detects changes and refreshes skills automatically"]
+    H --> E
+```
+
+## Feature Highlights
+
+| Capability | What Skilgen Does |
+| --- | --- |
+| Repo-native skill system | Generates `AGENTS.md`, `skills/`, and supporting docs directly inside the repo |
+| Automatic upkeep | Detects code changes and refreshes skills without repeated manual runs |
+| Quality standard | Computes a `Skilgen Score` that grades the health of the skill tree |
+| Project understanding | Builds domain graphs, reports, feature maps, and refresh priorities |
+| Enterprise skills | Ingests and manages organization-wide skill packs |
+| External skills | Installs, ranks, activates, and syncs public skill ecosystems |
+| Official MCP handling | Recommends and activates approved official OAuth-ready MCP connectors |
+| Agent decision support | Tells agents what to load first and what context matters most |
+| Reproducibility | Tracks state, memory, provenance, trust, and lockfile-backed skill setups |
+
+## Why It Matters
+
+Most AI workflows lose time on re-explaining context.
+
+Skilgen makes that context reusable.
+
+It gives agents:
+- project-specific guidance instead of generic prompting
+- stable memory and refresh signals instead of stale assumptions
+- stronger execution patterns instead of ad-hoc improvisation
+- a one-stop shop for both generated repo skills and external skill ecosystems
+
+That means agents do not just work faster. They work with better judgment.
+
+## At A Glance
+
+| You Have | Skilgen Produces | Why It Helps |
+| --- | --- | --- |
+| Existing codebase | domain graph, skills, reports, agent contract | agents understand the actual repo before changing it |
+| Requirements document | feature intent, roadmap, starter skills | agents can plan before implementation exists |
+| Codebase + requirements | highest-fidelity operating context | agents align shipped behavior with planned scope |
+| External skill ecosystems | installable, rankable, managed skill packs | agents can pull in trusted skills from one place |
+
+## What Skilgen Handles Automatically
+
+Once initialized in a repo, Skilgen can automatically:
+- detect repository changes and refresh skills
+- preserve existing `skilgen.yml` config instead of overwriting it
+- keep repo-local agent context current for Codex, Claude Code, and Cursor
+- detect ecosystem signals such as LangChain, Anthropic, Hugging Face, and more
+- ingest configured enterprise skill packs
+- recommend official MCP connectors from repo evidence
+- auto-activate only connectors that pass enterprise policy checks such as official-source and OAuth requirements
+- keep freshness, memory, and status state under `.skilgen/`
+
+## What You Get Fast
+
+- `AGENTS.md` for the top-level agent contract
+- `FEATURES.md` for product behavior
+- `REPORT.md` for project-level understanding
+- `TRACEABILITY.md` for source-to-output reasoning
+- `skills/MANIFEST.md` and `skills/**/SKILL.md` for execution-ready guidance
+- `.skilgen/state/` and `.skilgen/memory/` for freshness and continuity
+
+## Quick Mental Model
+
+- Skilgen reads your project
+- Skilgen materializes the right skills and docs
+- agents load those skills instead of guessing
+- external ecosystems can also be installed and managed through Skilgen
+
+## What A Great Score Looks Like
+
+- `90+`
+  - excellent
+  - skills are grounded, current, complete, and structurally healthy
+- `75-89`
+  - strong
+  - the repo has a solid skill system with a few remaining gaps
+- `60-74`
+  - fair
+  - usable, but one or more quality gates are holding it back
+- `<60`
+  - needs work
+  - the skill system is either stale, weakly grounded, incomplete, or under-mapped
+
+The goal is not just to generate more files.
+The goal is to keep a high-confidence, high-quality skill system that agents can trust.
+
+## What Skilgen Understands
+
+Skilgen can work from:
+- an existing codebase
+- a requirements document such as a PRD
+- both together when you want implementation-aware planning
+
+From those inputs, Skilgen synthesizes:
+- feature intent
+- entities and domain boundaries
+- backend endpoints and service areas
+- frontend flows and component zones
+- roadmap phases
+- dynamic domain graphs inferred from the real repo
+- freshness signals for when skills should refresh
+- in-flight run memory for agent continuity
+- reusable skill guidance for agents
+
+## What You Get
+
+Generated outputs can include:
+- `AGENTS.md`
+- `ANALYSIS.md`
+- `FEATURES.md`
+- `REPORT.md`
+- `TRACEABILITY.md`
+- `skills/MANIFEST.md`
+- `skills/GRAPH.md`
+- dynamic top-level and child `skills/**`
+- `.skilgen/state/freshness.json`
+- `.skilgen/memory/current_run.json`
+- `.skilgen/memory/runs/<run_id>.json`
+
+This gives your agents:
+- a stable memory layer
+- reusable execution guidance
+- project-specific context instead of generic prompting
+- refresh decisions grounded in actual repo change signals
+- a better path toward consistent, high-quality, engineering-standard delivery
+
+## Installation Options
+
+Install Skilgen from source:
+
+```bash
+python -m pip install .
+```
+
+Requirements:
+- Python 3.11+
+- The model-backed runtime requires Python 3.11+
+
+Runtime behavior:
+- If you configure a supported model provider and API key, Skilgen uses the full model-backed runtime.
+- If you do not provide an API key, Skilgen falls back to local deterministic analysis.
+- The fallback mode still works, but it is less intelligent and less complete than the full model-backed runtime.
+
+Initialize config in your repo:
+
+```bash
+skilgen init --project-root .
+```
+
+`skilgen init` now writes a provider-neutral `skilgen.yml` by default, so it does not assume OpenAI unless you explicitly want that.
+
+If you want provider-specific starter values:
+
+```bash
+skilgen init --project-root . --provider openai
+skilgen init --project-root . --provider anthropic
+skilgen init --project-root . --provider gemini
+skilgen init --project-root . --provider huggingface
+```
+
+Analyze a codebase:
+
+```bash
+skilgen fingerprint --project-root .
+```
+
+Diagnose runtime readiness:
+
+```bash
+skilgen doctor --project-root .
+```
+
+Decide whether skills should refresh and what an agent should load first:
+
+```bash
+skilgen decide --project-root .
+```
+
+Generate docs and skills from just the codebase:
+
+```bash
+skilgen deliver --project-root .
+```
+
+Interpret a requirements document:
+
+```bash
+skilgen intent --requirements docs/product-requirements.docx
+```
+
+Build a feature model from the repo and requirements:
+
+```bash
+skilgen features --requirements docs/product-requirements.docx --project-root .
+```
+
+Build a roadmap:
+
+```bash
+skilgen plan --requirements docs/product-requirements.docx --project-root .
+```
+
+Generate the full skills system from codebase + requirements:
+
+```bash
+skilgen deliver --requirements docs/product-requirements.docx --project-root .
+```
+
+## Progress Feedback
+
+Skilgen explains long-running work in plain English while it runs.
+
+CLI example:
+
+```text
+[skilgen] Starting delivery with the model_backed runtime. This may take a bit while Skilgen builds project context and generates the final skill tree.
+[skilgen] Reading your codebase and requirements and loading the Skilgen project configuration.
+[skilgen] Building project context so agents can understand the repo structure and delivery scope.
+[skilgen] Inspecting the codebase to identify frameworks, domains, and implementation patterns.
+[skilgen] Generating project docs so coding agents have clear context, traceability, and operating guidance.
+[skilgen] Materializing backend, frontend, requirements, and roadmap skills for coding agents.
+[skilgen] Finished delivery. Generated or refreshed 24 files.
+```
+
+API example:
+
+```json
+{
+  "api_version": "1.0",
+  "runtime": "model_backed",
+  "runtime_diagnostics": {
+    "provider": "openai",
+    "model": "gpt-4.1-mini",
+    "api_key_present": true
+  },
+  "events": [
+    {"message": "Reading your codebase and requirements and loading the Skilgen project configuration."},
+    {"message": "Building project context so agents can understand the repo structure and delivery scope."},
+    {"message": "Generating project docs so coding agents have clear context, traceability, and operating guidance."}
+  ],
+  "generated_files": [
+    "AGENTS.md",
+    "FEATURES.md",
+    "skills/MANIFEST.md"
+  ]
+}
+```
+
+Background jobs expose the same style of progress through job status:
+- `progress` for a simple numeric indicator
+- `message` for the current step
+- `events` for the history of user-facing updates
+
+Feature synthesis example:
+
+```text
+[skilgen] Starting feature synthesis with the model_backed runtime. Skilgen is reading the project context to identify the capabilities that matter.
+[skilgen] Reading the codebase and optional requirements to identify product capabilities.
+[skilgen] Grouping detected backend, frontend, and planning signals into a reusable feature inventory.
+```
+
+Roadmap planning example:
+
+```text
+[skilgen] Starting roadmap planning with the model_backed runtime. Skilgen is turning project context into a staged implementation plan.
+[skilgen] Reading project scope and available inputs for roadmap planning.
+[skilgen] Synthesizing implementation phases and sequencing the next delivery steps.
+```
+
+## Core Commands
+
+- `skilgen init` writes a default `skilgen.yml`
+- `skilgen doctor` explains runtime readiness, provider setup, and missing credentials
+- `skilgen fingerprint` detects the likely stack of the current codebase
+- `skilgen intent` interprets a requirements document into structured intent
+- `skilgen features` builds a feature inventory from a codebase, requirements, or both
+- `skilgen plan` generates a roadmap view from a codebase, requirements, or both
+- `skilgen decide` tells agents whether to refresh skills, which domains to prioritize, and which memory files to load
+- `skilgen scan` generates docs and skills from the codebase and optionally a requirements file
+- `skilgen deliver` runs the main generation flow with or without a requirements file
+
+## Example Output
+
+```text
+.
+├── AGENTS.md
+├── ANALYSIS.md
+├── FEATURES.md
+├── REPORT.md
+├── TRACEABILITY.md
+├── .skilgen
+│   ├── state
+│   │   └── freshness.json
+│   └── memory
+│       ├── current_run.json
+│       └── runs
+│           └── <run_id>.json
+├── skilgen.yml
+└── skills
+    ├── MANIFEST.md
+    ├── GRAPH.md
+    ├── requirements
+    ├── roadmap
+    ├── ...dynamically generated domain families
+    └── ...additional inferred child skills
+```
+
+## First-Class Examples
+
+- `examples/codebase-only/README.md`: minimal repo scan without a requirements document
+- `examples/requirements-only/README.md`: requirements-driven generation from a spec alone
+- `examples/codebase-and-requirements/README.md`: combined high-fidelity generation flow
+
+## Model Configuration
+
+Skilgen reads runtime settings from `skilgen.yml`.
 
 ```yaml
 include_paths:
@@ -308,80 +480,115 @@ exclude_paths:
   - __pycache__
   - .venv
   - node_modules
-  - .skilgen
-
+domains_override:
 skill_depth: 2
-update_trigger: auto           # auto | watch | manual
-
-# Model — pick your provider
-model_provider: anthropic      # openai | anthropic | gemini | huggingface | groq | openrouter
-model: claude-sonnet-4-5
-api_key_env: ANTHROPIC_API_KEY
-
-# External skills governance
-auto_install_external_skills: true
-external_skills_policy_mode: permissive   # permissive | restrictive
-external_skills_allowed_trust_levels:
-  - official
-  - spec
-  - community
-  - curated
-
-# Enterprise MCP connector policy
-auto_activate_mcp_connectors: true
-mcp_connectors_require_official_source: true
-mcp_connectors_require_oauth: true
-
-# Enterprise skill sources
-enterprise_skill_paths: []
-enterprise_skill_git_urls: []
+update_trigger: manual
+langsmith_project:
+# Set these to your preferred provider. For example:
+# openai / gpt-4.1-mini / OPENAI_API_KEY
+# anthropic / claude-sonnet-4-5 / ANTHROPIC_API_KEY
+# gemini / gemini-2.5-pro / GOOGLE_API_KEY
+# huggingface / meta-llama/Llama-3.1-70B-Instruct / HUGGINGFACEHUB_API_TOKEN
+model_provider:
+model:
+api_key_env:
+model_temperature:
+model_max_tokens:
+model_retry_attempts: 3
+model_retry_base_delay_seconds: 1.0
 ```
 
----
+Supported `model_provider` values:
+- `openai`
+- `anthropic`
+- `gemini`
+- `google`
+- `google_genai`
+- `huggingface`
+- `hugging_face`
+- `hf`
 
-## Agent Skills Compatible
+Default API key environment mapping:
+- `openai` -> `OPENAI_API_KEY`
+- `anthropic` -> `ANTHROPIC_API_KEY`
+- `gemini` / `google_genai` -> `GOOGLE_API_KEY`
+- `huggingface` -> `HUGGINGFACEHUB_API_TOKEN`
 
-Skilgen generates skills that follow the [Agent Skills open standard](https://agentskills.io/specification). Every `SKILL.md` output works with:
+Important:
+- Without a valid provider API key, Skilgen will not use LLMs.
+- In that case, it runs in local fallback mode for analysis and generation.
+- Local fallback mode is faster, but it does not have the same reasoning depth or synthesis quality as the full model-backed path.
+- Skilgen retries transient provider failures such as rate limits, timeouts, and temporary upstream outages.
+- Use `model_retry_attempts` and `model_retry_base_delay_seconds` when you want to tune model-backed resilience.
 
-- **Claude Code** — drop into `.claude/skills/`
-- **OpenAI Codex** — drop into `.agents/skills/`
-- **GitHub Copilot** — discovered automatically in VS Code
-- **Cursor, Windsurf, Gemini CLI, OpenCode, Roo Code** — all compatible
+Example Anthropic config:
 
----
+```yaml
+model_provider: anthropic
+model: claude-sonnet-4-5
+api_key_env: ANTHROPIC_API_KEY
+model_temperature: 0.1
+model_max_tokens: 4096
+```
+
+Example Gemini config:
+
+```yaml
+model_provider: gemini
+model: gemini-2.5-pro
+api_key_env: GOOGLE_API_KEY
+```
+
+Example Hugging Face config:
+
+```yaml
+model_provider: huggingface
+model: meta-llama/Llama-3.1-70B-Instruct
+api_key_env: HUGGINGFACEHUB_API_TOKEN
+```
+
+## How It Works
+
+1. Read the codebase, the requirements source, or both.
+2. Interpret product intent and implementation shape.
+3. Infer a dynamic domain graph and choose the right skill topology.
+4. Build feature, roadmap, traceability, and agent guidance.
+5. Persist freshness state and in-flight run memory.
+6. Generate project docs and materialize a reusable `skills/` tree.
+
+That means the same repo can become:
+- planning context for humans
+- execution guidance for agents
+- a project memory layer that evolves with the codebase
+- a freshness-aware system that knows when skills should be refreshed
+- a quality layer that helps agents choose stronger patterns and produce better code
 
 ## Best For
 
-- **AI-first teams** that use Claude Code, Codex, or Copilot daily
-- **Enterprise codebases** with complex domain boundaries and compliance needs
-- **Greenfield projects** starting from a PRD — get agent-ready skills before writing code
-- **Existing repos** where agents keep making the same mistakes because they lack context
-- **Platform teams** building internal developer tools around AI agents
-
----
+- AI-first developer tools
+- fast-moving startup repos
+- greenfield products starting from a PRD
+- existing codebases that need better agent context
+- teams that want reusable backend, frontend, and roadmap guidance in one place
 
 ## Status
 
-- **v0.4.0** — stable, published on [PyPI](https://pypi.org/project/skilgen/)
-- 6 model providers supported
-- Auto-update, freshness tracking, and project memory are production-ready
-- Curated external skill catalog with trust scoring and version locking
-- Enterprise MCP connector discovery with OAuth and security metadata
-- Full Python SDK, CLI, and HTTP API
-
----
+- OpenAI has been tested live in this repo
+- Anthropic, Gemini, and Hugging Face are wired through config and dependencies
+- provider-aware error handling is built in for auth failures, rate limits, missing models, and transient upstream issues
+- use `--project-root` to point Skilgen at any codebase
+- `--requirements` is optional for `features`, `plan`, `scan`, and `deliver`
+- `decide` uses freshness, run memory, and the inferred domain graph to guide the next agent step
+- skill families can now expand beyond the original fixed seed taxonomy when the repo structure demands it
+- replace `docs/product-requirements.docx` with your own requirements path when you want requirements-aware generation
+- Skilgen now persists `.skilgen/state/` and `.skilgen/memory/` to support selective refresh and continuity
+- run `skilgen doctor --project-root .` when you want to verify provider setup before a model-backed run
+- for full model-backed quality, set a supported provider API key before running Skilgen
 
 ## Contributing
 
-Contributions are welcome. See the repo for guidelines.
-
-## License
-
-[MIT](LICENSE)
-
----
-
-<p align="center">
-  <strong>Stop re-explaining your codebase to every agent.</strong><br/>
-  Let Skilgen build the context layer that keeps them smart.
-</p>
+- Open a bug report or feature request with the issue templates in `.github/ISSUE_TEMPLATE/`
+- Use pull requests for all changes to `main`
+- Run `python -m unittest discover -s tests` before opening a PR
+- If backend behavior changes, test every affected endpoint on both happy and failure paths
+- See `CHANGELOG.md` for release history and upcoming release notes

--- a/skilgen/__init__.py
+++ b/skilgen/__init__.py
@@ -28,6 +28,7 @@ from skilgen.sdk import (
     plan_project,
     preview_project,
     project_report,
+    project_score,
     project_status,
     rank_skill_sources,
     recommend_project_mcp_connectors,
@@ -44,6 +45,8 @@ from skilgen.sdk import (
     update_project,
     validate_project_outputs,
     watch_project,
+    scaffold_eval,
+    compare_evals,
 )
 
 __version__ = "0.4.1"
@@ -76,6 +79,7 @@ __all__ = [
     "plan_project",
     "preview_project",
     "project_report",
+    "project_score",
     "project_status",
     "rank_skill_sources",
     "recommend_project_mcp_connectors",
@@ -95,4 +99,6 @@ __all__ = [
     "update_project",
     "validate_project_outputs",
     "watch_project",
+    "scaffold_eval",
+    "compare_evals",
 ]

--- a/skilgen/api/server.py
+++ b/skilgen/api/server.py
@@ -30,6 +30,8 @@ from skilgen.api.service import (
     preview_payload,
     resume_job_payload,
     report_payload,
+    score_badge_payload,
+    score_payload,
     skills_activate_payload,
     skills_active_payload,
     skills_deactivate_payload,
@@ -59,6 +61,15 @@ def _json_response(handler: BaseHTTPRequestHandler, status_code: int, payload: d
     handler.wfile.write(body)
 
 
+def _svg_response(handler: BaseHTTPRequestHandler, status_code: int, body: str) -> None:
+    payload = body.encode("utf-8")
+    handler.send_response(status_code)
+    handler.send_header("Content-Type", "image/svg+xml")
+    handler.send_header("Content-Length", str(len(payload)))
+    handler.end_headers()
+    handler.wfile.write(payload)
+
+
 def _read_json(handler: BaseHTTPRequestHandler) -> dict[str, object]:
     length = int(handler.headers.get("Content-Length", "0"))
     body = handler.rfile.read(length) if length else b"{}"
@@ -75,6 +86,16 @@ def create_handler() -> type[BaseHTTPRequestHandler]:
                 return
             if parsed.path == "/status":
                 _json_response(self, 200, status_payload(query.get("project_root", ["."])[0]))
+                return
+            if parsed.path == "/score":
+                _json_response(
+                    self,
+                    200,
+                    score_payload(query.get("project_root", ["."])[0], query.get("badge_file", [None])[0]),
+                )
+                return
+            if parsed.path == "/badge.svg":
+                _svg_response(self, 200, score_badge_payload(query.get("project_root", ["."])[0]))
                 return
             if parsed.path == "/doctor":
                 _json_response(self, 200, doctor_payload(query.get("project_root", ["."])[0]))

--- a/skilgen/api/service.py
+++ b/skilgen/api/service.py
@@ -34,6 +34,7 @@ from skilgen.enterprise_skills import (
 )
 from skilgen.core.freshness import compute_freshness_report, load_freshness_state
 from skilgen.core.context import build_codebase_context
+from skilgen.core.score import compute_skillgen_score, render_score_badge_svg, write_score_badge
 from skilgen.core.requirements import load_project_context
 from skilgen.core.run_memory import load_current_run_memory
 from skilgen.external_skills import (
@@ -297,8 +298,21 @@ def status_payload(project_root: str | Path) -> dict[str, object]:
             "recommended_mcp_connectors": recommend_mcp_connectors(root),
             "active_mcp_connectors": active_mcp_connectors(root),
             "auto_update": auto_update_status(root),
+            "skilgen_score": compute_skillgen_score(root),
         }
     )
+
+
+def score_payload(project_root: str | Path, badge_file: str | Path | None = None) -> dict[str, object]:
+    root = Path(project_root).resolve()
+    payload = compute_skillgen_score(root)
+    if badge_file is not None:
+        payload["badge_file"] = write_score_badge(root, badge_file)
+    return _with_api_meta(payload)
+
+
+def score_badge_payload(project_root: str | Path) -> str:
+    return render_score_badge_svg(compute_skillgen_score(Path(project_root).resolve()))
 
 
 def skills_list_payload(project_root: str | Path, ecosystem: str | None = None, search: str | None = None) -> dict[str, object]:
@@ -478,10 +492,10 @@ def report_payload(project_root: str | Path) -> dict[str, object]:
 def validate_payload(project_root: str | Path) -> dict[str, object]:
     root = Path(project_root).resolve()
     runtime = DeepAgentsRuntime(root)
-    return _with_api_meta(
-        runtime.run(
+    payload = runtime.run(
             "validate",
             f"Validate project_root={root}. Return JSON with valid, errors, warnings, coverage, and completeness_score.",
             lambda: native_validate_payload(root),
         )
-    )
+    payload["skilgen_score"] = compute_skillgen_score(root)
+    return _with_api_meta(payload)

--- a/skilgen/autoupdate.py
+++ b/skilgen/autoupdate.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from skilgen.core.config import load_config
+from skilgen.core.repo_state import classify_repo_change, git_repo_state
 from skilgen.delivery import run_delivery
 
 
@@ -82,7 +83,7 @@ def _record_requirements_path(project_root: Path, requirements_path: str | Path 
     path.write_text("" if requirements_path is None else str(Path(requirements_path).resolve()), encoding="utf-8")
 
 
-def _snapshot(project_root: Path) -> dict[str, int]:
+def _file_snapshot(project_root: Path) -> dict[str, int]:
     tracked: dict[str, int] = {}
     for path in project_root.rglob("*"):
         if not path.is_file():
@@ -94,6 +95,13 @@ def _snapshot(project_root: Path) -> dict[str, int]:
             continue
         tracked[relative] = path.stat().st_mtime_ns
     return tracked
+
+
+def _snapshot(project_root: Path) -> dict[str, object]:
+    return {
+        "files": _file_snapshot(project_root),
+        "git": git_repo_state(project_root),
+    }
 
 
 def ensure_auto_update_worker(
@@ -189,12 +197,14 @@ def run_auto_update_worker(project_root: str | Path, *, interval_seconds: float 
         current = _snapshot(root)
         if current == previous:
             continue
+        change = classify_repo_change(previous, current)
         requirements = _requirements_path_for_worker(root)
         run_delivery(requirements, root)
         payload = {
             **payload,
             "last_run_at": _timestamp(),
-            "last_event": "repository_changed",
+            "last_event": change["event_type"],
+            "last_change_summary": change,
         }
         _write_state(root, payload)
         previous = current

--- a/skilgen/cli/main.py
+++ b/skilgen/cli/main.py
@@ -7,11 +7,12 @@ from pathlib import Path
 
 from skilgen.api.server import run_server
 from skilgen.autoupdate import auto_update_status, ensure_auto_update_worker, run_auto_update_worker, stop_auto_update_worker
-from skilgen.api.service import analyze_payload, decision_payload, doctor_payload, preview_payload, report_payload, status_payload, validate_payload
+from skilgen.api.service import analyze_payload, decision_payload, doctor_payload, preview_payload, report_payload, score_payload, status_payload, validate_payload
 from skilgen import __version__
 from skilgen.agents import build_import_graph, build_roadmap_plan, extract_features, fingerprint_project
 from skilgen.agents.requirements_parser import parse_project_intent, parse_requirements_file
 from skilgen.deep_agents_core import current_runtime_mode, runtime_diagnostics
+from skilgen.core.evals import compare_eval_results, scaffold_eval_framework
 from skilgen.delivery import run_delivery, watch_delivery
 from skilgen.core.config import load_config, render_default_config
 from skilgen.enterprise_skills import (
@@ -248,6 +249,19 @@ def build_parser() -> argparse.ArgumentParser:
     plan = subparsers.add_parser("plan", help="Build a roadmap plan from requirements and model config.")
     plan.add_argument("--requirements")
     plan.add_argument("--project-root", default=".")
+
+    score = subparsers.add_parser("score", help="Compute the Skilgen Score quality metric for the current skill tree.")
+    score.add_argument("--project-root", default=".")
+    score.add_argument("--badge-file")
+
+    eval_cmd = subparsers.add_parser("eval", help="Scaffold or compare Skilgen evaluation runs.")
+    eval_subparsers = eval_cmd.add_subparsers(dest="eval_command", required=True)
+    eval_scaffold = eval_subparsers.add_parser("scaffold", help="Create a starter eval framework for with-vs-without-Skilgen comparisons.")
+    eval_scaffold.add_argument("--project-root", default=".")
+    eval_scaffold.add_argument("--output-dir")
+    eval_compare = eval_subparsers.add_parser("compare", help="Compare baseline and Skilgen eval results.")
+    eval_compare.add_argument("--baseline", required=True)
+    eval_compare.add_argument("--skilgen", required=True)
 
     status = subparsers.add_parser("status", help="Show the current generated output status for a project root.")
     status.add_argument("--project-root", default=".")
@@ -519,6 +533,19 @@ def main() -> None:
             )
         )
         return
+    if args.command == "score":
+        emit_progress("Computing the Skilgen Score from groundedness, coverage, freshness, and structure signals.")
+        print(json.dumps(score_payload(Path(args.project_root).resolve(), args.badge_file), indent=2))
+        return
+    if args.command == "eval":
+        if args.eval_command == "scaffold":
+            emit_progress("Creating a starter eval framework for baseline-vs-Skilgen comparisons.")
+            print(json.dumps(scaffold_eval_framework(Path(args.project_root).resolve(), args.output_dir), indent=2))
+            return
+        if args.eval_command == "compare":
+            emit_progress("Comparing baseline and Skilgen eval results.")
+            print(json.dumps(compare_eval_results(args.baseline, args.skilgen), indent=2))
+            return
     if args.command == "status":
         print(json.dumps(status_payload(Path(args.project_root).resolve()), indent=2))
         return

--- a/skilgen/core/evals.py
+++ b/skilgen/core/evals.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+EXAMPLE_BASELINE = {
+    "label": "baseline",
+    "tasks_total": 10,
+    "tasks_passed": 6,
+    "success_rate": 0.6,
+    "token_usage": 42000,
+    "error_count": 9,
+}
+
+EXAMPLE_SKILGEN = {
+    "label": "skilgen",
+    "tasks_total": 10,
+    "tasks_passed": 8,
+    "success_rate": 0.8,
+    "token_usage": 35500,
+    "error_count": 4,
+}
+
+
+def scaffold_eval_framework(project_root: str | Path, output_dir: str | Path | None = None) -> dict[str, object]:
+    root = Path(project_root).resolve()
+    target = Path(output_dir).resolve() if output_dir is not None else root / ".skilgen" / "evals"
+    tasks_dir = target / "tasks"
+    results_dir = target / "results"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    example_task = {
+        "id": "complex-refactor-001",
+        "prompt": "Implement a non-trivial change in this codebase with and without Skilgen-generated skills loaded.",
+        "success_criteria": [
+            "All affected tests pass",
+            "No new validation warnings",
+            "Required files are updated consistently",
+        ],
+        "measurements": ["success_rate", "token_usage", "error_count"],
+    }
+
+    (tasks_dir / "example-task.json").write_text(json.dumps(example_task, indent=2), encoding="utf-8")
+    (results_dir / "baseline.example.json").write_text(json.dumps(EXAMPLE_BASELINE, indent=2), encoding="utf-8")
+    (results_dir / "skilgen.example.json").write_text(json.dumps(EXAMPLE_SKILGEN, indent=2), encoding="utf-8")
+    (target / "README.md").write_text(
+        "\n".join(
+            [
+                "# Skilgen Eval Framework",
+                "",
+                "Use this folder to benchmark an agent with and without Skilgen-generated skills on the same task set.",
+                "",
+                "## Suggested Flow",
+                "1. Define one or more task files in `tasks/`.",
+                "2. Run the same task with a baseline agent setup and save results in `results/baseline.*.json`.",
+                "3. Run the same task with Skilgen-generated skills enabled and save results in `results/skilgen.*.json`.",
+                "4. Compare them with `skilgen eval compare --baseline ... --skilgen ...`.",
+                "",
+                "## Result File Fields",
+                "- `tasks_total`",
+                "- `tasks_passed`",
+                "- `success_rate` (0-1)",
+                "- `token_usage`",
+                "- `error_count`",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return {
+        "output_dir": str(target),
+        "files": [
+            str(tasks_dir / "example-task.json"),
+            str(results_dir / "baseline.example.json"),
+            str(results_dir / "skilgen.example.json"),
+            str(target / "README.md"),
+        ],
+    }
+
+
+def compare_eval_results(baseline_path: str | Path, skilgen_path: str | Path) -> dict[str, object]:
+    baseline = json.loads(Path(baseline_path).resolve().read_text(encoding="utf-8"))
+    skilgen = json.loads(Path(skilgen_path).resolve().read_text(encoding="utf-8"))
+
+    baseline_success = float(baseline.get("success_rate", 0.0))
+    skilgen_success = float(skilgen.get("success_rate", 0.0))
+    baseline_tokens = float(baseline.get("token_usage", 0.0))
+    skilgen_tokens = float(skilgen.get("token_usage", 0.0))
+    baseline_errors = float(baseline.get("error_count", 0.0))
+    skilgen_errors = float(skilgen.get("error_count", 0.0))
+
+    success_delta = skilgen_success - baseline_success
+    token_delta = skilgen_tokens - baseline_tokens
+    error_delta = skilgen_errors - baseline_errors
+    error_reduction_pct = 0.0 if baseline_errors == 0 else ((baseline_errors - skilgen_errors) / baseline_errors) * 100
+    token_delta_pct = 0.0 if baseline_tokens == 0 else ((skilgen_tokens - baseline_tokens) / baseline_tokens) * 100
+
+    headline = (
+        f"Agents using Skilgen skills improved success rate by {success_delta * 100:.1f} points, "
+        f"changed token usage by {token_delta_pct:.1f}%, and reduced errors by {error_reduction_pct:.1f}%."
+    )
+
+    return {
+        "baseline": baseline,
+        "skilgen": skilgen,
+        "comparison": {
+            "success_rate_delta": round(success_delta, 4),
+            "token_usage_delta": round(token_delta, 2),
+            "token_usage_delta_pct": round(token_delta_pct, 2),
+            "error_count_delta": round(error_delta, 2),
+            "error_reduction_pct": round(error_reduction_pct, 2),
+        },
+        "headline": headline,
+    }

--- a/skilgen/core/repo_state.py
+++ b/skilgen/core/repo_state.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _git_dir(project_root: Path) -> Path | None:
+    result = subprocess.run(
+        ["git", "-C", str(project_root), "rev-parse", "--git-dir"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    git_dir = Path(result.stdout.strip())
+    if not git_dir.is_absolute():
+        git_dir = (project_root / git_dir).resolve()
+    return git_dir
+
+
+def _git_output(project_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(project_root), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _git_lines(project_root: Path, *args: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(project_root), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    return result.stdout.splitlines()
+
+
+def git_repo_state(project_root: str | Path) -> dict[str, object]:
+    root = Path(project_root).resolve()
+    git_dir = _git_dir(root)
+    if git_dir is None:
+        return {
+            "is_git_repo": False,
+            "head": None,
+            "branch": None,
+            "merge_in_progress": False,
+            "rebase_in_progress": False,
+            "staged_changes": 0,
+            "unstaged_changes": 0,
+            "untracked_files": 0,
+            "head_parent_count": 0,
+        }
+
+    status_lines = _git_lines(root, "status", "--porcelain=v1")
+    staged_changes = 0
+    unstaged_changes = 0
+    untracked_files = 0
+    for line in status_lines:
+        if not line:
+            continue
+        if line.startswith("??"):
+            untracked_files += 1
+            continue
+        if len(line) >= 2:
+            if line[0] != " ":
+                staged_changes += 1
+            if line[1] != " ":
+                unstaged_changes += 1
+
+    head = _git_output(root, "rev-parse", "HEAD") or None
+    branch = _git_output(root, "rev-parse", "--abbrev-ref", "HEAD") or None
+    parents = _git_output(root, "rev-list", "--parents", "-n", "1", "HEAD").split()
+    head_parent_count = max(0, len(parents) - 1)
+    rebase_in_progress = (git_dir / "rebase-merge").exists() or (git_dir / "rebase-apply").exists()
+    merge_in_progress = (git_dir / "MERGE_HEAD").exists()
+    return {
+        "is_git_repo": True,
+        "head": head,
+        "branch": branch,
+        "merge_in_progress": merge_in_progress,
+        "rebase_in_progress": rebase_in_progress,
+        "staged_changes": staged_changes,
+        "unstaged_changes": unstaged_changes,
+        "untracked_files": untracked_files,
+        "head_parent_count": head_parent_count,
+    }
+
+
+def classify_repo_change(previous: dict[str, object], current: dict[str, object]) -> dict[str, object]:
+    prev_git = previous.get("git", {}) if isinstance(previous.get("git"), dict) else {}
+    curr_git = current.get("git", {}) if isinstance(current.get("git"), dict) else {}
+
+    prev_files = previous.get("files", {})
+    curr_files = current.get("files", {})
+    changed_paths = sorted(
+        set(prev_files) ^ set(curr_files)
+        | {path for path in set(prev_files) & set(curr_files) if prev_files[path] != curr_files[path]}
+    )
+    head_changed = prev_git.get("head") != curr_git.get("head")
+    branch_changed = prev_git.get("branch") != curr_git.get("branch")
+
+    if curr_git.get("merge_in_progress") or prev_git.get("merge_in_progress"):
+        event_type = "merge_in_progress"
+    elif curr_git.get("rebase_in_progress") or prev_git.get("rebase_in_progress"):
+        event_type = "rebase_in_progress"
+    elif head_changed and curr_git.get("head_parent_count", 0) > 1:
+        event_type = "merge_commit"
+    elif head_changed and (branch_changed or prev_git.get("rebase_in_progress")):
+        event_type = "rebase_or_history_rewrite"
+    elif head_changed:
+        event_type = "git_head_changed"
+    elif curr_git.get("staged_changes", 0) != prev_git.get("staged_changes", 0):
+        event_type = "staged_changes"
+    elif curr_git.get("unstaged_changes", 0) != prev_git.get("unstaged_changes", 0):
+        event_type = "manual_edit"
+    elif curr_git.get("untracked_files", 0) != prev_git.get("untracked_files", 0):
+        event_type = "new_untracked_files"
+    else:
+        event_type = "file_change"
+
+    return {
+        "event_type": event_type,
+        "head_changed": head_changed,
+        "branch_changed": branch_changed,
+        "changed_paths": changed_paths[:25],
+        "changed_path_count": len(changed_paths),
+        "git": curr_git,
+    }

--- a/skilgen/core/score.py
+++ b/skilgen/core/score.py
@@ -91,6 +91,58 @@ def _skill_domain(skill: Path, project_root: Path) -> str | None:
     return relative.parts[0] if relative.parts else None
 
 
+def _nodes_by_domain(project_root: Path) -> dict[str, list[object]]:
+    context = load_project_context(project_root, None)
+    codebase_context = build_codebase_context(project_root, context)
+    grouped: dict[str, list[object]] = {}
+    for node in codebase_context.domain_graph.nodes:
+        grouped.setdefault(node.name, []).append(node)
+    return grouped
+
+
+def _domain_key_files(project_root: Path) -> dict[str, list[str]]:
+    grouped = _nodes_by_domain(project_root)
+    return {
+        domain: list(dict.fromkeys(file for node in nodes for file in node.key_files))
+        for domain, nodes in grouped.items()
+    }
+
+
+def _skill_content(skill: Path) -> str:
+    return skill.read_text(encoding="utf-8").lower()
+
+
+def _evidence_hits_for_skill(skill: Path, project_root: Path, key_files: list[str]) -> dict[str, int]:
+    content = _skill_content(skill)
+    references = _parse_references(skill)
+    checks = _parse_check_paths(skill)
+    valid_references = sum(1 for ref in references if (skill.parent / ref).resolve().exists())
+    valid_checks = sum(1 for check in checks if _resolve_placeholder_path(check, project_root, skill).exists())
+    evidence_targets = min(3, len(key_files))
+    evidence_mentions = 0
+    covered_key_files: set[str] = set()
+    for key_file in key_files:
+        file_name = Path(key_file).name.lower()
+        if key_file.lower() in content or file_name in content:
+            covered_key_files.add(key_file)
+    for key_file in key_files[:3]:
+        file_name = Path(key_file).name.lower()
+        if key_file.lower() in content or file_name in content:
+            evidence_mentions += 1
+    generic_markers = sum(content.count(marker) for marker in GENERIC_MARKERS)
+    return {
+        "valid_references": valid_references,
+        "total_references": len(references),
+        "valid_check_paths": valid_checks,
+        "total_check_paths": len(checks),
+        "evidence_mentions": evidence_mentions,
+        "evidence_targets": evidence_targets,
+        "generic_advice_markers": generic_markers,
+        "covered_key_files": len(covered_key_files),
+        "total_key_files": len(key_files),
+    }
+
+
 def _groundedness_score(project_root: Path) -> tuple[float, dict[str, object]]:
     skill_files = _skill_files(project_root)
     if not skill_files:
@@ -159,6 +211,46 @@ def _groundedness_score(project_root: Path) -> tuple[float, dict[str, object]]:
     }
 
 
+def _groundedness_score_for_skills(project_root: Path, skill_files: list[Path], domain_key_files: dict[str, list[str]]) -> tuple[float, dict[str, object]]:
+    if not skill_files:
+        return 0.0, {
+            "score": 0.0,
+            "max_score": 25,
+            "valid_references": 0,
+            "total_references": 0,
+            "valid_check_paths": 0,
+            "total_check_paths": 0,
+            "evidence_mentions": 0,
+            "evidence_targets": 0,
+            "generic_advice_markers": 0,
+        }
+
+    totals = {
+        "valid_references": 0,
+        "total_references": 0,
+        "valid_check_paths": 0,
+        "total_check_paths": 0,
+        "evidence_mentions": 0,
+        "evidence_targets": 0,
+        "generic_advice_markers": 0,
+    }
+    for skill in skill_files:
+        domain = _skill_domain(skill, project_root) or ""
+        hits = _evidence_hits_for_skill(skill, project_root, domain_key_files.get(domain, []))
+        for key in totals:
+            totals[key] += hits[key]
+
+    possible = totals["total_references"] + totals["total_check_paths"] + totals["evidence_targets"]
+    raw_ratio = (totals["valid_references"] + totals["valid_check_paths"] + totals["evidence_mentions"]) / max(1, possible)
+    generic_penalty = min(0.35, totals["generic_advice_markers"] / max(20, len(skill_files) * 12))
+    score = max(0.0, min(25.0, round(25 * raw_ratio * (1 - generic_penalty), 2)))
+    return score, {
+        "score": score,
+        "max_score": 25,
+        **totals,
+    }
+
+
 def _coverage_score(project_root: Path) -> tuple[float, dict[str, object]]:
     source_files = _iter_source_files(project_root)
     if not source_files:
@@ -220,6 +312,32 @@ def _freshness_score(project_root: Path) -> tuple[float, dict[str, object]]:
     }
 
 
+def _freshness_score_for_skill(
+    skill_path: Path,
+    changed_files: list[str],
+    stale_skill_paths: list[str],
+    domain_key_files: list[str],
+    project_root: Path,
+    base_reason: str,
+) -> tuple[float, dict[str, object]]:
+    relative_skill = skill_path.relative_to(project_root).as_posix()
+    stale = relative_skill in stale_skill_paths
+    domain_changed = sum(1 for path in changed_files if path in set(domain_key_files))
+    if base_reason == "missing_freshness_state":
+        score = 5.0
+    elif not stale and domain_changed == 0:
+        score = 25.0
+    else:
+        score = max(0.0, round(25 - (8.0 if stale else 0.0) - min(17.0, domain_changed * 4.0), 2))
+    return score, {
+        "score": score,
+        "max_score": 25,
+        "reason": base_reason if base_reason == "missing_freshness_state" else ("stale" if stale else "changed_domain"),
+        "domain_changed_files": domain_changed,
+        "stale": stale,
+    }
+
+
 def _structure_score(project_root: Path) -> tuple[float, dict[str, object]]:
     validation = validate_project(project_root)
     requirements = load_project_context(project_root, None)
@@ -249,6 +367,36 @@ def _structure_score(project_root: Path) -> tuple[float, dict[str, object]]:
         "cross_reference_density": round(density, 4),
         "validation_errors": structure_errors,
         "validation_warnings": structure_warnings,
+    }
+
+
+def _structure_score_for_skills(project_root: Path, skill_files: list[Path]) -> tuple[float, dict[str, object]]:
+    if not skill_files:
+        return 0.0, {
+            "score": 0.0,
+            "max_score": 25,
+            "skill_count": 0,
+            "cross_reference_density": 0.0,
+            "summary_siblings_present": 0,
+        }
+    cross_reference_count = 0
+    summary_siblings_present = 0
+    for skill in skill_files:
+        refs = _parse_references(skill)
+        cross_reference_count += len(refs)
+        if (skill.parent / "SUMMARY.md").exists():
+            summary_siblings_present += 1
+    density = cross_reference_count / max(1, len(skill_files))
+    density_bonus = min(10.0, round(density * 4, 2))
+    summary_bonus = min(10.0, round((summary_siblings_present / len(skill_files)) * 10, 2))
+    base = 5.0
+    score = max(0.0, min(25.0, round(base + density_bonus + summary_bonus, 2)))
+    return score, {
+        "score": score,
+        "max_score": 25,
+        "skill_count": len(skill_files),
+        "cross_reference_density": round(density, 4),
+        "summary_siblings_present": summary_siblings_present,
     }
 
 
@@ -313,7 +461,9 @@ def _quality_gates(subscores: dict[str, object]) -> tuple[list[dict[str, object]
             }
         )
 
-    if structure["required_artifacts_present"] < structure["required_artifacts_total"]:
+    required_present = structure.get("required_artifacts_present", structure.get("summary_siblings_present", 0))
+    required_total = structure.get("required_artifacts_total", structure.get("skill_count", 0))
+    if required_total > 0 and required_present < required_total:
         gates.append(
             {
                 "name": "structure_gate",
@@ -321,7 +471,7 @@ def _quality_gates(subscores: dict[str, object]) -> tuple[list[dict[str, object]
                 "reason": "Core skill-system artifacts are missing, so the tree is not structurally complete.",
             }
         )
-    elif structure["validation_errors"] > 0:
+    elif structure.get("validation_errors", 0) > 0:
         gates.append(
             {
                 "name": "validation_gate",
@@ -370,41 +520,156 @@ def build_score_recommendations(scorecard: dict[str, object]) -> list[str]:
     return recommendations
 
 
+def _assemble_scorecard(
+    *,
+    score_scope: str,
+    score_id: str,
+    project_root: Path,
+    subscores: dict[str, object],
+    extra: dict[str, object] | None = None,
+) -> dict[str, object]:
+    raw_total = round(sum(component["score"] for component in subscores.values()), 2)
+    gates, cap = _quality_gates(subscores)
+    total = raw_total if cap is None else round(min(raw_total, cap), 2)
+    scorecard = {
+        "scope": score_scope,
+        "id": score_id,
+        "project_root": str(project_root),
+        "score": total,
+        "raw_score": raw_total,
+        "max_score": 100,
+        "rating": _score_rating(total),
+        "subscores": subscores,
+        "quality_gates": gates,
+    }
+    if extra:
+        scorecard.update(extra)
+    scorecard["recommendations"] = build_score_recommendations(scorecard)
+    return scorecard
+
+
+def _domain_scorecards(project_root: Path) -> list[dict[str, object]]:
+    domain_files = _domain_key_files(project_root)
+    previous = load_freshness_state(project_root)
+    context = load_project_context(project_root, None)
+    codebase_context = build_codebase_context(project_root, context)
+    freshness = compute_freshness_report(project_root, context, codebase_context.domain_graph, previous)
+    all_skills = _skill_files(project_root)
+    scorecards: list[dict[str, object]] = []
+    for domain, key_files in sorted(domain_files.items()):
+        domain_skills = [skill for skill in all_skills if _skill_domain(skill, project_root) == domain]
+        groundedness_score, groundedness = _groundedness_score_for_skills(project_root, domain_skills, domain_files)
+        coverage_ratio = min(1.0, len(key_files) / max(1, len(_iter_source_files(project_root))))
+        coverage = {
+            "score": round(25 * coverage_ratio, 2),
+            "max_score": 25,
+            "source_file_count": len(key_files),
+            "mapped_file_count": len(key_files),
+            "coverage_ratio": round(coverage_ratio, 4),
+        }
+        stale_domain_skills = [path for path in freshness.stale_skill_paths if path.startswith(f"skills/{domain}/")]
+        freshness_score = max(0.0, round(25 - min(10.0, len(stale_domain_skills) * 4.0), 2))
+        freshness_payload = {
+            "score": freshness_score,
+            "max_score": 25,
+            "reason": freshness.reason if stale_domain_skills else "current",
+            "changed_files": sum(1 for file in freshness.changed_files if file in set(key_files)),
+            "stale_skill_paths": len(stale_domain_skills),
+        }
+        structure_score, structure = _structure_score_for_skills(project_root, domain_skills)
+        scorecards.append(
+            _assemble_scorecard(
+                score_scope="domain",
+                score_id=domain,
+                project_root=project_root,
+                subscores={
+                    "groundedness": groundedness,
+                    "coverage": coverage,
+                    "freshness": freshness_payload,
+                    "structure": structure,
+                },
+                extra={
+                    "domain": domain,
+                    "skill_count": len(domain_skills),
+                    "key_file_count": len(key_files),
+                },
+            )
+        )
+    return scorecards
+
+
+def _skill_scorecards(project_root: Path) -> list[dict[str, object]]:
+    domain_files = _domain_key_files(project_root)
+    previous = load_freshness_state(project_root)
+    context = load_project_context(project_root, None)
+    codebase_context = build_codebase_context(project_root, context)
+    freshness = compute_freshness_report(project_root, context, codebase_context.domain_graph, previous)
+    scorecards: list[dict[str, object]] = []
+    for skill in _skill_files(project_root):
+        domain = _skill_domain(skill, project_root) or "unscoped"
+        key_files = domain_files.get(domain, [])
+        groundedness_score, groundedness = _groundedness_score_for_skills(project_root, [skill], domain_files)
+        hits = _evidence_hits_for_skill(skill, project_root, key_files)
+        coverage_ratio = hits["covered_key_files"] / max(1, hits["total_key_files"])
+        coverage = {
+            "score": round(25 * coverage_ratio, 2),
+            "max_score": 25,
+            "source_file_count": hits["total_key_files"],
+            "mapped_file_count": hits["covered_key_files"],
+            "coverage_ratio": round(coverage_ratio, 4),
+        }
+        freshness_score, freshness_payload = _freshness_score_for_skill(
+            skill,
+            freshness.changed_files,
+            freshness.stale_skill_paths,
+            key_files,
+            project_root,
+            freshness.reason,
+        )
+        structure_score, structure = _structure_score_for_skills(project_root, [skill])
+        scorecards.append(
+            _assemble_scorecard(
+                score_scope="skill",
+                score_id=skill.relative_to(project_root).as_posix(),
+                project_root=project_root,
+                subscores={
+                    "groundedness": groundedness,
+                    "coverage": coverage,
+                    "freshness": freshness_payload,
+                    "structure": structure,
+                },
+                extra={
+                    "path": skill.relative_to(project_root).as_posix(),
+                    "domain": domain,
+                },
+            )
+        )
+    return scorecards
+
+
 def compute_skillgen_score(project_root: str | Path) -> dict[str, object]:
     root = Path(project_root).resolve()
     groundedness_score, groundedness = _groundedness_score(root)
     coverage_score, coverage = _coverage_score(root)
     freshness_score, freshness = _freshness_score(root)
     structure_score, structure = _structure_score(root)
-    raw_total = round(groundedness_score + coverage_score + freshness_score + structure_score, 2)
-    gates, cap = _quality_gates(
-        {
-            "groundedness": groundedness,
-            "coverage": coverage,
-            "freshness": freshness,
-            "structure": structure,
-        }
-    )
-    total = raw_total if cap is None else round(min(raw_total, cap), 2)
-    scorecard = {
-        "project_root": str(root),
-        "score": total,
-        "raw_score": raw_total,
-        "max_score": 100,
-        "rating": _score_rating(total),
-        "subscores": {
+    scorecard = _assemble_scorecard(
+        score_scope="repo",
+        score_id="repo",
+        project_root=root,
+        subscores={
             "groundedness": groundedness,
             "coverage": coverage,
             "freshness": freshness,
             "structure": structure,
         },
-        "quality_gates": gates,
-    }
-    scorecard["recommendations"] = build_score_recommendations(scorecard)
+    )
+    scorecard["domains"] = _domain_scorecards(root)
+    scorecard["skills"] = _skill_scorecards(root)
     scorecard["badge"] = {
         "label": "Skilgen Score",
-        "message": f"{int(round(total))}/100",
-        "color": _badge_color(total),
+        "message": f"{int(round(scorecard['score']))}/100",
+        "color": _badge_color(scorecard["score"]),
         "markdown_example": "![Skilgen Score](https://skilgen.com/badge/your-repo)",
     }
     return scorecard

--- a/skilgen/core/score.py
+++ b/skilgen/core/score.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from skilgen.core.context import build_codebase_context
+from skilgen.core.freshness import compute_freshness_report, load_freshness_state
+from skilgen.core.requirements import load_project_context
+from skilgen.core.validation import validate_project
+
+
+GENERIC_MARKERS = (
+    "best practice",
+    "consider",
+    "appropriate",
+    "where applicable",
+    "generally",
+    "typically",
+)
+
+
+def _iter_source_files(project_root: Path) -> list[Path]:
+    ignored_roots = {".git", ".venv", "venv", "node_modules", "__pycache__", "dist", "build", ".skilgen", "skills"}
+    ignored_files = {"AGENTS.md", "ANALYSIS.md", "FEATURES.md", "REPORT.md", "TRACEABILITY.md"}
+    files: list[Path] = []
+    for path in project_root.rglob("*"):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(project_root)
+        if set(relative.parts) & ignored_roots:
+            continue
+        if path.name in ignored_files:
+            continue
+        files.append(path)
+    return sorted(files)
+
+
+def _skill_files(project_root: Path) -> list[Path]:
+    skills_root = project_root / "skills"
+    if not skills_root.exists():
+        return []
+    return sorted(skills_root.rglob("SKILL.md"))
+
+
+def _parse_references(skill: Path) -> list[str]:
+    refs: list[str] = []
+    lines = skill.read_text(encoding="utf-8").splitlines()
+    in_refs = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "references:":
+            in_refs = True
+            continue
+        if in_refs and stripped.startswith("- "):
+            refs.append(stripped[2:].strip())
+        elif in_refs and stripped and not stripped.startswith("- "):
+            in_refs = False
+    return refs
+
+
+def _parse_check_paths(skill: Path) -> list[str]:
+    checks: list[str] = []
+    lines = skill.read_text(encoding="utf-8").splitlines()
+    in_checks = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "## Check These Paths First":
+            in_checks = True
+            continue
+        if in_checks and stripped.startswith("## "):
+            break
+        if in_checks and stripped.startswith("- "):
+            checks.append(stripped[2:].strip())
+    return checks
+
+
+def _resolve_placeholder_path(raw: str, project_root: Path, skill_path: Path) -> Path:
+    normalized = raw.replace("{{project_root}}", str(project_root)).replace("{{skill_dir}}", str(skill_path.parent))
+    candidate = Path(normalized)
+    if candidate.is_absolute():
+        return candidate
+    return (skill_path.parent / normalized).resolve()
+
+
+def _skill_domain(skill: Path, project_root: Path) -> str | None:
+    try:
+        relative = skill.relative_to(project_root / "skills")
+    except ValueError:
+        return None
+    return relative.parts[0] if relative.parts else None
+
+
+def _groundedness_score(project_root: Path) -> tuple[float, dict[str, object]]:
+    skill_files = _skill_files(project_root)
+    if not skill_files:
+        return 0.0, {
+            "score": 0.0,
+            "max_score": 25,
+            "valid_references": 0,
+            "valid_check_paths": 0,
+            "evidence_mentions": 0,
+            "generic_advice_markers": 0,
+        }
+
+    context = load_project_context(project_root, None)
+    codebase_context = build_codebase_context(project_root, context)
+    nodes_by_domain: dict[str, list[object]] = {}
+    for node in codebase_context.domain_graph.nodes:
+        nodes_by_domain.setdefault(node.name, []).append(node)
+
+    valid_references = 0
+    total_references = 0
+    valid_checks = 0
+    total_checks = 0
+    evidence_mentions = 0
+    evidence_targets = 0
+    generic_markers = 0
+
+    for skill in skill_files:
+        content = skill.read_text(encoding="utf-8").lower()
+        references = _parse_references(skill)
+        total_references += len(references)
+        for ref in references:
+            if (skill.parent / ref).resolve().exists():
+                valid_references += 1
+
+        checks = _parse_check_paths(skill)
+        total_checks += len(checks)
+        for check in checks:
+            resolved = _resolve_placeholder_path(check, project_root, skill)
+            if resolved.exists():
+                valid_checks += 1
+
+        domain = _skill_domain(skill, project_root)
+        nodes = nodes_by_domain.get(domain or "", [])
+        domain_key_files = list(dict.fromkeys(file for node in nodes for file in node.key_files))
+        evidence_targets += min(3, len(domain_key_files))
+        for key_file in domain_key_files[:3]:
+            if key_file.lower() in content or Path(key_file).name.lower() in content:
+                evidence_mentions += 1
+
+        generic_markers += sum(content.count(marker) for marker in GENERIC_MARKERS)
+
+    possible = total_references + total_checks + evidence_targets
+    raw_ratio = (valid_references + valid_checks + evidence_mentions) / max(1, possible)
+    generic_penalty = min(0.35, generic_markers / max(20, len(skill_files) * 12))
+    score = max(0.0, min(25.0, round(25 * raw_ratio * (1 - generic_penalty), 2)))
+    return score, {
+        "score": score,
+        "max_score": 25,
+        "valid_references": valid_references,
+        "total_references": total_references,
+        "valid_check_paths": valid_checks,
+        "total_check_paths": total_checks,
+        "evidence_mentions": evidence_mentions,
+        "evidence_targets": evidence_targets,
+        "generic_advice_markers": generic_markers,
+    }
+
+
+def _coverage_score(project_root: Path) -> tuple[float, dict[str, object]]:
+    source_files = _iter_source_files(project_root)
+    if not source_files:
+        return 25.0, {
+            "score": 25.0,
+            "max_score": 25,
+            "source_file_count": 0,
+            "mapped_file_count": 0,
+            "coverage_ratio": 1.0,
+        }
+
+    context = load_project_context(project_root, None)
+    codebase_context = build_codebase_context(project_root, context)
+    source_paths = {path.relative_to(project_root).as_posix() for path in source_files}
+    mapped_files = {
+        key_file
+        for node in codebase_context.domain_graph.nodes
+        for key_file in node.key_files
+        if key_file in source_paths
+    }
+    ratio = len(mapped_files) / max(1, len(source_paths))
+    score = round(25 * ratio, 2)
+    return score, {
+        "score": score,
+        "max_score": 25,
+        "source_file_count": len(source_paths),
+        "mapped_file_count": len(mapped_files),
+        "coverage_ratio": round(ratio, 4),
+    }
+
+
+def _freshness_score(project_root: Path) -> tuple[float, dict[str, object]]:
+    context = load_project_context(project_root, None)
+    codebase_context = build_codebase_context(project_root, context)
+    previous = load_freshness_state(project_root)
+    if previous is None:
+        return 5.0, {
+            "score": 5.0,
+            "max_score": 25,
+            "reason": "missing_freshness_state",
+            "changed_files": 0,
+            "stale_skill_paths": 0,
+        }
+    freshness = compute_freshness_report(project_root, context, codebase_context.domain_graph, previous)
+    if freshness.reason == "no_source_changes":
+        score = 25.0
+    elif freshness.reason == "initial_generation":
+        score = 18.0
+    else:
+        changed_penalty = min(15.0, len(freshness.changed_files) * 1.5)
+        stale_penalty = min(10.0, len(freshness.stale_skill_paths) * 0.75)
+        score = max(0.0, round(25 - changed_penalty - stale_penalty, 2))
+    return score, {
+        "score": score,
+        "max_score": 25,
+        "reason": freshness.reason,
+        "changed_files": len(freshness.changed_files),
+        "stale_skill_paths": len(freshness.stale_skill_paths),
+    }
+
+
+def _structure_score(project_root: Path) -> tuple[float, dict[str, object]]:
+    validation = validate_project(project_root)
+    requirements = load_project_context(project_root, None)
+    codebase_context = build_codebase_context(project_root, requirements)
+    required = [
+        project_root / "AGENTS.md",
+        project_root / "FEATURES.md",
+        project_root / "TRACEABILITY.md",
+        project_root / "skills" / "MANIFEST.md",
+        project_root / "skills" / "GRAPH.md",
+    ]
+    existing_required = sum(1 for item in required if item.exists())
+    base = 15 * (existing_required / len(required))
+    cross_reference_count = sum(len(node.cross_references) + len(node.child_skills) for node in codebase_context.skill_tree)
+    density = cross_reference_count / max(1, len(codebase_context.skill_tree))
+    density_bonus = min(6.0, round(density * 3, 2))
+    tree_bonus = min(4.0, float(len(codebase_context.skill_tree)))
+    structure_errors = len(validation["errors"])
+    structure_warnings = len(validation["warnings"])
+    penalty = min(10.0, structure_errors * 2.5 + structure_warnings * 0.5)
+    score = max(0.0, min(25.0, round(base + density_bonus + tree_bonus - penalty, 2)))
+    return score, {
+        "score": score,
+        "max_score": 25,
+        "required_artifacts_present": existing_required,
+        "required_artifacts_total": len(required),
+        "cross_reference_density": round(density, 4),
+        "validation_errors": structure_errors,
+        "validation_warnings": structure_warnings,
+    }
+
+
+def _quality_gates(subscores: dict[str, object]) -> tuple[list[dict[str, object]], float | None]:
+    gates: list[dict[str, object]] = []
+    groundedness = subscores["groundedness"]
+    coverage = subscores["coverage"]
+    freshness = subscores["freshness"]
+    structure = subscores["structure"]
+
+    if groundedness["score"] < 10 or (
+        groundedness.get("valid_references", 0) + groundedness.get("valid_check_paths", 0) + groundedness.get("evidence_mentions", 0)
+    ) < 4:
+        gates.append(
+            {
+                "name": "groundedness_gate",
+                "cap": 59.0,
+                "reason": "Skill guidance is not grounded enough in real files, real check paths, or inferred domain evidence.",
+            }
+        )
+    elif groundedness["score"] < 16:
+        gates.append(
+            {
+                "name": "groundedness_gate_soft",
+                "cap": 74.0,
+                "reason": "Skill guidance still needs more concrete repo evidence before it should count as strong.",
+            }
+        )
+
+    if coverage["coverage_ratio"] < 0.2:
+        gates.append(
+            {
+                "name": "coverage_gate",
+                "cap": 59.0,
+                "reason": "Too little of the codebase is mapped into inferred skill domains.",
+            }
+        )
+    elif coverage["coverage_ratio"] < 0.4:
+        gates.append(
+            {
+                "name": "coverage_gate_soft",
+                "cap": 74.0,
+                "reason": "Coverage is still partial; major parts of the repo are not yet represented by the skill tree.",
+            }
+        )
+
+    freshness_reason = freshness.get("reason")
+    if freshness_reason == "missing_freshness_state":
+        gates.append(
+            {
+                "name": "freshness_state_gate",
+                "cap": 74.0,
+                "reason": "Freshness state is missing, so Skilgen cannot verify whether the skills are current.",
+            }
+        )
+    elif freshness.get("changed_files", 0) > 0 or freshness.get("stale_skill_paths", 0) > 0:
+        gates.append(
+            {
+                "name": "freshness_gate",
+                "cap": 59.0,
+                "reason": "Skills are stale relative to current source changes.",
+            }
+        )
+
+    if structure["required_artifacts_present"] < structure["required_artifacts_total"]:
+        gates.append(
+            {
+                "name": "structure_gate",
+                "cap": 69.0,
+                "reason": "Core skill-system artifacts are missing, so the tree is not structurally complete.",
+            }
+        )
+    elif structure["validation_errors"] > 0:
+        gates.append(
+            {
+                "name": "validation_gate",
+                "cap": 74.0,
+                "reason": "Validation errors are present in the generated skill system.",
+            }
+        )
+
+    cap = min((gate["cap"] for gate in gates), default=None)
+    return gates, cap
+
+
+def _score_rating(score: float) -> str:
+    if score >= 90:
+        return "excellent"
+    if score >= 75:
+        return "strong"
+    if score >= 60:
+        return "fair"
+    return "needs-work"
+
+
+def _badge_color(score: float) -> str:
+    if score >= 90:
+        return "#2ea043"
+    if score >= 75:
+        return "#3fb950"
+    if score >= 60:
+        return "#d29922"
+    return "#cf222e"
+
+
+def build_score_recommendations(scorecard: dict[str, object]) -> list[str]:
+    recommendations: list[str] = []
+    subscores = scorecard["subscores"]
+    if subscores["groundedness"]["score"] < 18:
+        recommendations.append("Increase groundedness by adding more real file references and concrete check paths inside generated skills.")
+    if subscores["coverage"]["score"] < 18:
+        recommendations.append("Improve coverage by mapping more source files into inferred domains and regenerating the skill tree.")
+    if subscores["freshness"]["score"] < 18:
+        recommendations.append("Refresh stale skills with `skilgen deliver` or enable `update_trigger: auto` so the freshness score stays high.")
+    if subscores["structure"]["score"] < 18:
+        recommendations.append("Strengthen structure by keeping AGENTS.md, MANIFEST.md, GRAPH.md, TRACEABILITY.md, and cross-references in sync.")
+    if not recommendations:
+        recommendations.append("Skilgen Score looks healthy. Keep the repo-local skill tree refreshed and preserve grounded references as the code evolves.")
+    return recommendations
+
+
+def compute_skillgen_score(project_root: str | Path) -> dict[str, object]:
+    root = Path(project_root).resolve()
+    groundedness_score, groundedness = _groundedness_score(root)
+    coverage_score, coverage = _coverage_score(root)
+    freshness_score, freshness = _freshness_score(root)
+    structure_score, structure = _structure_score(root)
+    raw_total = round(groundedness_score + coverage_score + freshness_score + structure_score, 2)
+    gates, cap = _quality_gates(
+        {
+            "groundedness": groundedness,
+            "coverage": coverage,
+            "freshness": freshness,
+            "structure": structure,
+        }
+    )
+    total = raw_total if cap is None else round(min(raw_total, cap), 2)
+    scorecard = {
+        "project_root": str(root),
+        "score": total,
+        "raw_score": raw_total,
+        "max_score": 100,
+        "rating": _score_rating(total),
+        "subscores": {
+            "groundedness": groundedness,
+            "coverage": coverage,
+            "freshness": freshness,
+            "structure": structure,
+        },
+        "quality_gates": gates,
+    }
+    scorecard["recommendations"] = build_score_recommendations(scorecard)
+    scorecard["badge"] = {
+        "label": "Skilgen Score",
+        "message": f"{int(round(total))}/100",
+        "color": _badge_color(total),
+        "markdown_example": "![Skilgen Score](https://skilgen.com/badge/your-repo)",
+    }
+    return scorecard
+
+
+def render_score_badge_svg(score_payload: dict[str, object]) -> str:
+    label = "Skilgen Score"
+    message = score_payload["badge"]["message"]
+    color = score_payload["badge"]["color"]
+    label_width = 108
+    value_width = 58
+    width = label_width + value_width
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="20" role="img" aria-label="{label}: {message}">
+<linearGradient id="smooth" x2="0" y2="100%">
+  <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+  <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+  <stop offset=".9" stop-color="#000" stop-opacity=".3"/>
+  <stop offset="1" stop-color="#000" stop-opacity=".5"/>
+</linearGradient>
+<mask id="round">
+  <rect width="{width}" height="20" rx="3" fill="#fff"/>
+</mask>
+<g mask="url(#round)">
+  <rect width="{label_width}" height="20" fill="#24292f"/>
+  <rect x="{label_width}" width="{value_width}" height="20" fill="{color}"/>
+  <rect width="{width}" height="20" fill="url(#smooth)"/>
+</g>
+<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+  <text x="{label_width / 2}" y="15" fill="#010101" fill-opacity=".3">{label}</text>
+  <text x="{label_width / 2}" y="14">{label}</text>
+  <text x="{label_width + value_width / 2}" y="15" fill="#010101" fill-opacity=".3">{message}</text>
+  <text x="{label_width + value_width / 2}" y="14">{message}</text>
+</g>
+</svg>"""
+
+
+def write_score_badge(project_root: str | Path, output_path: str | Path | None = None) -> dict[str, object]:
+    root = Path(project_root).resolve()
+    payload = compute_skillgen_score(root)
+    path = Path(output_path).resolve() if output_path is not None else root / ".skilgen" / "score" / "badge.svg"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_score_badge_svg(payload), encoding="utf-8")
+    return {
+        "path": str(path),
+        "score": payload["score"],
+        "rating": payload["rating"],
+    }
+
+
+def score_summary_markdown(project_root: str | Path) -> str:
+    payload = compute_skillgen_score(project_root)
+    return "\n".join(
+        [
+            f"## Skilgen Score: {int(round(payload['score']))}/100",
+            "",
+            f"- Groundedness: {payload['subscores']['groundedness']['score']}/25",
+            f"- Coverage: {payload['subscores']['coverage']['score']}/25",
+            f"- Freshness: {payload['subscores']['freshness']['score']}/25",
+            f"- Structure: {payload['subscores']['structure']['score']}/25",
+        ]
+    )
+
+
+def export_score_json(project_root: str | Path, output_path: str | Path | None = None) -> dict[str, object]:
+    root = Path(project_root).resolve()
+    payload = compute_skillgen_score(root)
+    path = Path(output_path).resolve() if output_path is not None else root / ".skilgen" / "score" / "score.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return {
+        "path": str(path),
+        "score": payload["score"],
+    }

--- a/skilgen/core/score.py
+++ b/skilgen/core/score.py
@@ -91,6 +91,10 @@ def _skill_domain(skill: Path, project_root: Path) -> str | None:
     return relative.parts[0] if relative.parts else None
 
 
+def _materialized_domains(project_root: Path) -> list[str]:
+    return sorted({domain for skill in _skill_files(project_root) if (domain := _skill_domain(skill, project_root))})
+
+
 def _nodes_by_domain(project_root: Path) -> dict[str, list[object]]:
     context = load_project_context(project_root, None)
     codebase_context = build_codebase_context(project_root, context)
@@ -555,8 +559,10 @@ def _domain_scorecards(project_root: Path) -> list[dict[str, object]]:
     codebase_context = build_codebase_context(project_root, context)
     freshness = compute_freshness_report(project_root, context, codebase_context.domain_graph, previous)
     all_skills = _skill_files(project_root)
+    materialized_domains = _materialized_domains(project_root)
     scorecards: list[dict[str, object]] = []
-    for domain, key_files in sorted(domain_files.items()):
+    for domain in materialized_domains:
+        key_files = domain_files.get(domain, [])
         domain_skills = [skill for skill in all_skills if _skill_domain(skill, project_root) == domain]
         groundedness_score, groundedness = _groundedness_score_for_skills(project_root, domain_skills, domain_files)
         coverage_ratio = min(1.0, len(key_files) / max(1, len(_iter_source_files(project_root))))
@@ -592,6 +598,7 @@ def _domain_scorecards(project_root: Path) -> list[dict[str, object]]:
                     "domain": domain,
                     "skill_count": len(domain_skills),
                     "key_file_count": len(key_files),
+                    "materialized": True,
                 },
             )
         )
@@ -649,6 +656,7 @@ def _skill_scorecards(project_root: Path) -> list[dict[str, object]]:
 
 def compute_skillgen_score(project_root: str | Path) -> dict[str, object]:
     root = Path(project_root).resolve()
+    domain_files = _domain_key_files(root)
     groundedness_score, groundedness = _groundedness_score(root)
     coverage_score, coverage = _coverage_score(root)
     freshness_score, freshness = _freshness_score(root)
@@ -666,6 +674,8 @@ def compute_skillgen_score(project_root: str | Path) -> dict[str, object]:
     )
     scorecard["domains"] = _domain_scorecards(root)
     scorecard["skills"] = _skill_scorecards(root)
+    scorecard["materialized_domains"] = [entry["domain"] for entry in scorecard["domains"]]
+    scorecard["inferred_only_domains"] = sorted(set(domain_files) - set(scorecard["materialized_domains"]))
     scorecard["badge"] = {
         "label": "Skilgen Score",
         "message": f"{int(round(scorecard['score']))}/100",

--- a/skilgen/deep_agents_runtime.py
+++ b/skilgen/deep_agents_runtime.py
@@ -17,6 +17,7 @@ from skilgen.core.config import load_config
 from skilgen.core.context import build_codebase_context
 from skilgen.core.requirements import load_project_context, load_requirements
 from skilgen.core.validation import validate_project
+from skilgen.core.score import compute_skillgen_score
 from skilgen.generators.package import (
     project_doc_paths,
     render_analysis_report,
@@ -370,6 +371,7 @@ def native_report_payload(project_root: str | Path) -> dict[str, Any]:
     skill_domains = sorted({Path(path).parts[1] for path in status["skill_files"]}) if status["skill_files"] else []
     return {
         "status": status,
+        "skilgen_score": compute_skillgen_score(root),
         "domains": skill_domains,
         "signal_counts": {
             "backend_routes": len(signals.backend_routes),

--- a/skilgen/delivery.py
+++ b/skilgen/delivery.py
@@ -9,6 +9,7 @@ from skilgen.core.config import load_config
 from skilgen.core.context import build_codebase_context
 from skilgen.core.freshness import compute_freshness_report, load_freshness_state, save_freshness_state, snapshot_freshness_state
 from skilgen.core.models import RunMemory
+from skilgen.core.repo_state import classify_repo_change, git_repo_state
 from skilgen.core.run_memory import append_run_event, create_run_memory, finalize_run_memory
 from skilgen.deep_agents_core import current_runtime_mode
 from skilgen.enterprise_skills import ensure_enterprise_skills_for_project
@@ -193,7 +194,7 @@ def watch_delivery(
 ) -> list[list[Path]]:
     root = Path(project_root).resolve()
 
-    def snapshot() -> dict[str, int]:
+    def snapshot() -> dict[str, object]:
         tracked: dict[str, int] = {}
         for path in root.rglob("*"):
             if not path.is_file():
@@ -204,7 +205,10 @@ def watch_delivery(
             if path.name in {"ANALYSIS.md", "FEATURES.md", "REPORT.md"}:
                 continue
             tracked[relative] = path.stat().st_mtime_ns
-        return tracked
+        return {
+            "files": tracked,
+            "git": git_repo_state(root),
+        }
 
     results = [
         run_delivery(
@@ -224,7 +228,8 @@ def watch_delivery(
         time.sleep(interval_seconds)
         current = snapshot()
         if current != previous:
-            _emit(progress_callback, "Detected repository changes. Refreshing the generated docs and skills.")
+            change = classify_repo_change(previous, current)
+            _emit(progress_callback, f"Detected {change['event_type'].replace('_', ' ')}. Refreshing the generated docs and skills.")
             results.append(
                 run_delivery(
                     requirements_path,

--- a/skilgen/sdk.py
+++ b/skilgen/sdk.py
@@ -15,6 +15,7 @@ from skilgen.api.service import (
     map_payload,
     plan_payload,
     preview_payload,
+    score_payload,
     resume_job_payload,
     report_payload,
     status_payload,
@@ -22,6 +23,7 @@ from skilgen.api.service import (
 )
 from skilgen.autoupdate import auto_update_status, ensure_auto_update_worker, stop_auto_update_worker
 from skilgen.core.config import render_default_config
+from skilgen.core.evals import compare_eval_results, scaffold_eval_framework
 from skilgen.delivery import run_delivery, watch_delivery
 from skilgen.enterprise_skills import (
     activate_mcp_connector,
@@ -151,6 +153,10 @@ def project_status(project_root: str | Path = ".") -> dict[str, object]:
     return status_payload(Path(project_root).resolve())
 
 
+def project_score(project_root: str | Path = ".", badge_file: str | Path | None = None) -> dict[str, object]:
+    return score_payload(Path(project_root).resolve(), badge_file)
+
+
 def start_auto_update(project_root: str | Path = ".", requirements: str | Path | None = None) -> dict[str, object]:
     resolved_requirements = Path(requirements).resolve() if requirements is not None else None
     return ensure_auto_update_worker(Path(project_root).resolve(), requirements_path=resolved_requirements)
@@ -170,6 +176,14 @@ def project_report(project_root: str | Path = ".") -> dict[str, object]:
 
 def validate_project_outputs(project_root: str | Path = ".") -> dict[str, object]:
     return validate_payload(Path(project_root).resolve())
+
+
+def scaffold_eval(project_root: str | Path = ".", output_dir: str | Path | None = None) -> dict[str, object]:
+    return scaffold_eval_framework(Path(project_root).resolve(), output_dir)
+
+
+def compare_evals(baseline_path: str | Path, skilgen_path: str | Path) -> dict[str, object]:
+    return compare_eval_results(baseline_path, skilgen_path)
 
 
 def start_deliver_job(requirements: str | Path, project_root: str | Path = ".") -> dict[str, object]:

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -99,6 +99,14 @@ class ApiSmokeTests(unittest.TestCase):
                 self.assertTrue(deliver["generated_files"])
                 self.assertIn("runtime_diagnostics", deliver)
 
+                score = get_json(f"{base}/score?{urlencode({'project_root': str(root)})}")
+                self.assertIn("score", score)
+                self.assertIn("subscores", score)
+
+                with urlopen(f"{base}/badge.svg?{urlencode({'project_root': str(root)})}") as response:  # noqa: S310
+                    badge = response.read().decode("utf-8")
+                self.assertIn("<svg", badge)
+
                 deliver_job = post_json(f"{base}/jobs/deliver", {"requirements": str(requirements), "project_root": str(root)})
                 self.assertIn(deliver_job["status"], {"queued", "running", "completed"})
                 self.assertEqual(deliver_job["job_type"], "deliver")
@@ -245,6 +253,7 @@ class ApiSmokeTests(unittest.TestCase):
                 self.assertIn("external_skill_lock", status)
                 self.assertIn("external_skill_policy", status)
                 self.assertIn("external_skill_recommendations", status)
+                self.assertIn("skilgen_score", status)
                 self.assertIn("pending_validations", status["current_run_memory"])
                 self.assertIn("resumable_steps", status["current_run_memory"])
 
@@ -259,6 +268,7 @@ class ApiSmokeTests(unittest.TestCase):
                 self.assertIn("coverage", validate)
                 self.assertIn("completeness_score", validate)
                 self.assertIn("recommendations", validate)
+                self.assertIn("skilgen_score", validate)
             finally:
                 server.shutdown()
                 server.server_close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,6 +162,28 @@ class CliTests(unittest.TestCase):
             self.assertEqual(len(payload["runs"]), 1)
             self.assertTrue(payload["runs"][0])
 
+    def test_score_command_exposes_quality_gates(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "src").mkdir()
+            (root / "src" / "app.py").write_text("def handler():\n    return {}\n", encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "skilgen.cli.main",
+                    "score",
+                    "--project-root",
+                    str(root),
+                ],
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            payload = json.loads(result.stdout)
+            self.assertIn("raw_score", payload)
+            self.assertIn("quality_gates", payload)
+
     def test_features_works_with_codebase_only(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -251,6 +273,80 @@ class CliTests(unittest.TestCase):
             payload = json.loads(result.stdout)
             self.assertTrue(payload["generated_files"])
             self.assertTrue((root / "FEATURES.md").exists())
+
+    def test_score_outputs_subscores_and_badge_file(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "api" / "routes").mkdir(parents=True)
+            (root / "api" / "routes" / "scan.py").write_text("def handler():\n    return {}\n", encoding="utf-8")
+            subprocess.run(
+                [sys.executable, "-m", "skilgen.cli.main", "deliver", "--project-root", str(root)],
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            badge_path = root / "badge.svg"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "skilgen.cli.main",
+                    "score",
+                    "--project-root",
+                    str(root),
+                    "--badge-file",
+                    str(badge_path),
+                ],
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            payload = json.loads(result.stdout)
+            self.assertIn("score", payload)
+            self.assertIn("subscores", payload)
+            self.assertIn("groundedness", payload["subscores"])
+            self.assertTrue(badge_path.exists())
+            self.assertIn("<svg", badge_path.read_text(encoding="utf-8"))
+
+    def test_eval_scaffold_and_compare_work(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scaffold = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "skilgen.cli.main",
+                    "eval",
+                    "scaffold",
+                    "--project-root",
+                    str(root),
+                ],
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            payload = json.loads(scaffold.stdout)
+            output_dir = Path(payload["output_dir"])
+            self.assertTrue((output_dir / "tasks" / "example-task.json").exists())
+            comparison = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "skilgen.cli.main",
+                    "eval",
+                    "compare",
+                    "--baseline",
+                    str(output_dir / "results" / "baseline.example.json"),
+                    "--skilgen",
+                    str(output_dir / "results" / "skilgen.example.json"),
+                ],
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            compared = json.loads(comparison.stdout)
+            self.assertIn("comparison", compared)
+            self.assertIn("headline", compared)
 
     def test_enterprise_ingest_and_connector_recommend(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -17,6 +17,39 @@ class ScoreTests(unittest.TestCase):
             self.assertIn("quality_gates", payload)
             self.assertTrue(payload["quality_gates"])
             self.assertLessEqual(payload["score"], payload["raw_score"])
+            self.assertIn("domains", payload)
+            self.assertIn("skills", payload)
+
+    def test_score_exposes_domain_and_skill_drilldowns(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "api" / "routes").mkdir(parents=True)
+            (root / "api" / "routes" / "scan.py").write_text("def handler():\n    return {}\n", encoding="utf-8")
+            (root / "skills" / "backend").mkdir(parents=True)
+            (root / "skills" / "backend" / "SKILL.md").write_text(
+                "\n".join(
+                    [
+                        "# Backend",
+                        "references:",
+                        "- ../MANIFEST.md",
+                        "## Check These Paths First",
+                        "- {{project_root}}/api/routes/scan.py",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (root / "skills" / "backend" / "SUMMARY.md").write_text("Backend summary\n", encoding="utf-8")
+            (root / "skills" / "MANIFEST.md").write_text("# Manifest\n", encoding="utf-8")
+            (root / "skills" / "GRAPH.md").write_text("# Graph\n", encoding="utf-8")
+            (root / "AGENTS.md").write_text("# Agents\n", encoding="utf-8")
+            (root / "FEATURES.md").write_text("# Features\n", encoding="utf-8")
+            (root / "TRACEABILITY.md").write_text("# Traceability\n", encoding="utf-8")
+
+            payload = compute_skillgen_score(root)
+            self.assertTrue(payload["domains"])
+            self.assertTrue(payload["skills"])
+            self.assertIn("domain", payload["domains"][0])
+            self.assertIn("path", payload["skills"][0])
 
     def test_classify_repo_change_detects_manual_edits(self) -> None:
         previous = {

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -50,6 +50,8 @@ class ScoreTests(unittest.TestCase):
             self.assertTrue(payload["skills"])
             self.assertIn("domain", payload["domains"][0])
             self.assertIn("path", payload["skills"][0])
+            self.assertEqual(payload["materialized_domains"], ["backend"])
+            self.assertIn("backend-api", payload["inferred_only_domains"])
 
     def test_classify_repo_change_detects_manual_edits(self) -> None:
         previous = {

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from skilgen.core.repo_state import classify_repo_change
+from skilgen.core.score import compute_skillgen_score
+
+
+class ScoreTests(unittest.TestCase):
+    def test_score_includes_quality_gates(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "src").mkdir()
+            (root / "src" / "app.py").write_text("def main():\n    return 1\n", encoding="utf-8")
+            payload = compute_skillgen_score(root)
+            self.assertIn("raw_score", payload)
+            self.assertIn("quality_gates", payload)
+            self.assertTrue(payload["quality_gates"])
+            self.assertLessEqual(payload["score"], payload["raw_score"])
+
+    def test_classify_repo_change_detects_manual_edits(self) -> None:
+        previous = {
+            "files": {"src/app.py": 1},
+            "git": {
+                "head": "abc",
+                "branch": "main",
+                "merge_in_progress": False,
+                "rebase_in_progress": False,
+                "staged_changes": 0,
+                "unstaged_changes": 0,
+                "untracked_files": 0,
+                "head_parent_count": 1,
+            },
+        }
+        current = {
+            "files": {"src/app.py": 2},
+            "git": {
+                "head": "abc",
+                "branch": "main",
+                "merge_in_progress": False,
+                "rebase_in_progress": False,
+                "staged_changes": 0,
+                "unstaged_changes": 1,
+                "untracked_files": 0,
+                "head_parent_count": 1,
+            },
+        }
+        payload = classify_repo_change(previous, current)
+        self.assertEqual(payload["event_type"], "manual_edit")
+
+    def test_classify_repo_change_detects_merge_commit(self) -> None:
+        previous = {
+            "files": {"src/app.py": 1},
+            "git": {
+                "head": "abc",
+                "branch": "main",
+                "merge_in_progress": False,
+                "rebase_in_progress": False,
+                "staged_changes": 0,
+                "unstaged_changes": 0,
+                "untracked_files": 0,
+                "head_parent_count": 1,
+            },
+        }
+        current = {
+            "files": {"src/app.py": 2},
+            "git": {
+                "head": "def",
+                "branch": "main",
+                "merge_in_progress": False,
+                "rebase_in_progress": False,
+                "staged_changes": 0,
+                "unstaged_changes": 0,
+                "untracked_files": 0,
+                "head_parent_count": 2,
+            },
+        }
+        payload = classify_repo_change(previous, current)
+        self.assertEqual(payload["event_type"], "merge_commit")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -39,6 +39,7 @@ from skilgen.sdk import (
     rank_skill_sources,
     recommend_project_mcp_connectors,
     project_report,
+    project_score,
     project_status,
     preview_project,
     remove_skill_source,
@@ -53,6 +54,8 @@ from skilgen.sdk import (
     update_project,
     validate_project_outputs,
     watch_project,
+    scaffold_eval,
+    compare_evals,
 )
 import time
 import subprocess
@@ -114,6 +117,11 @@ class SdkTests(unittest.TestCase):
             self.assertIn("agent_decision", status)
             self.assertIn("pending_validations", status["current_run_memory"])
             self.assertIn("resumable_steps", status["current_run_memory"])
+            self.assertIn("skilgen_score", status)
+
+            score = project_score(root)
+            self.assertIn("score", score)
+            self.assertIn("subscores", score)
 
             report = project_report(root)
             self.assertIn("summary", report)
@@ -123,12 +131,26 @@ class SdkTests(unittest.TestCase):
             self.assertIn("valid", validation)
             self.assertIn("warnings", validation)
             self.assertIn("completeness_score", validation)
+            self.assertIn("skilgen_score", validation)
 
             cancelled = cancel_job(job_id, root)
             self.assertIn(cancelled["status"], {"completed", "cancelled"})
             resumed = resume_job(job_id, root)
             self.assertIn(resumed.get("error", "ok"), {"resume_not_allowed", "ok"})
             stop_auto_update(root)
+
+    def test_sdk_can_scaffold_and_compare_evals(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            payload = scaffold_eval(root)
+            output_dir = Path(payload["output_dir"])
+            self.assertTrue((output_dir / "tasks" / "example-task.json").exists())
+            compared = compare_evals(
+                output_dir / "results" / "baseline.example.json",
+                output_dir / "results" / "skilgen.example.json",
+            )
+            self.assertIn("comparison", compared)
+            self.assertGreater(compared["comparison"]["success_rate_delta"], 0)
 
     def test_sdk_external_skills_catalog_and_install(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- Adds `Skilgen Score`, a Lighthouse-style quality metric for the repo’s skill system
- Introduces a `0-100` score with four `0-25` subscores:
  - groundedness
  - coverage
  - freshness
  - structure
- Makes the score opinionated by adding quality gates, so weak grounding, low coverage, stale skills, or missing core artifacts can cap the final score even when the raw score is higher
- Adds drill-down scoring so the output now includes:
  - repo score
  - dynamic materialized domain scores
  - per-`SKILL.md` scores
  - inferred-only domains as a separate signal
- Adds score and benchmark surfaces across the product:
  - `skilgen score`
  - `/score`
  - `/badge.svg`
  - eval scaffold and compare helpers
  - `skilgen-sync` GitHub Action
- Improves watcher/auto-update behavior by making repository change detection git-aware, so Skilgen can distinguish manual edits, head changes, merges, rebases, and related repo events
- Refreshes the README so the product is easier to understand quickly, with clearer quick-start setup, repo-local workflow, and Skilgen Score positioning

Why it matters:
- Skilgen now defines a measurable standard for what “good skills” look like
- teams can track repo-level skill quality, domain quality, and individual skill quality over time
- git-aware change detection makes automatic refresh behavior more trustworthy in real engineering workflows
- the README now makes setup, value, and scoring much easier to understand

## Validation

- [x] `python -m unittest discover -s tests`
- [x] Tested the affected CLI, API, or SDK flow
- [x] Tested all affected endpoints if backend behavior changed

Additional validation:
- Full suite passed on the validated branch state:
  - `80 tests`, `OK`
- Focused clean-clone regression passed:
  - `42 tests`, `OK`
- Manual CLI smoke checks passed for:
  - `skilgen score`
  - `skilgen eval scaffold`
  - `skilgen eval compare`
- Manual dynamic-scoring smoke passed on a sample repo:
  - repo score returned
  - materialized domain score returned
  - per-skill scores returned
  - inferred-only domains separated cleanly
- Real git smoke confirmed watcher classification for manual edits

## Output Impact

- [ ] `AGENTS.md`
- [ ] `FEATURES.md`
- [ ] `REPORT.md`
- [ ] `TRACEABILITY.md`
- [ ] `skills/` tree

## Notes

- `Skilgen Score` now returns both:
  - `raw_score`
  - final `score`
- The final score is quality-gated, so the output behaves more like a standard than a simple weighted average
- Domain scoring is intentionally based on materialized skill domains, while non-materialized inferred planner domains are exposed separately as `inferred_only_domains`
- The new git-aware watcher logic improves the signal behind auto-refresh behavior without changing the repo-local output contract
- The README has been rewritten to make the product easier to understand in the first screen
- No migration is required for existing users
- This PR adds a stronger standard and observability layer on top of the existing Skilgen workflow